### PR TITLE
Sprint 26: flesh out legacy screen with full life summary

### DIFF
--- a/src/engine/dispatch.ts
+++ b/src/engine/dispatch.ts
@@ -169,7 +169,14 @@ export function getState(): GameState {
 }
 
 export function dispatch(action: GameAction): void {
-  _state = applyAction(_state, action);
+  let _next = applyAction(_state, action);
+
+  // Sprint 26: track highest wizardFame reached this run.
+  if (_next.wizardFame > _next.peakWizardFame) {
+    _next = { ..._next, peakWizardFame: _next.wizardFame };
+  }
+
+  _state = _next;
 
   // Sprint 23: check for random event triggers after most actions.
   // Skip event checks during event resolution, setup, game over, and scratch phase.

--- a/src/state/initial.ts
+++ b/src/state/initial.ts
@@ -1,7 +1,7 @@
 import type { GameState } from './types';
 import balance from '../data/balance.json';
 
-export const SAVE_VERSION = 16;
+export const SAVE_VERSION = 17;
 
 export function createInitialState(): GameState {
   return {
@@ -27,6 +27,7 @@ export function createInitialState(): GameState {
     intelligence: balance.starting.intelligence,
     bookbinding: balance.starting.bookbinding,
     wizardFame: balance.starting.wizardFame,
+    peakWizardFame: 0,  // Sprint 26: starts at 0, updated via dispatch post-processing
     relaxationRate: balance.starting.relaxationRate,
     restingRelaxation: balance.starting.restingRelaxation,
     // Sprint 17: hidden addiction stats

--- a/src/state/save.ts
+++ b/src/state/save.ts
@@ -130,6 +130,11 @@ const MIGRATIONS: Record<number, (s: unknown) => unknown> = {
       lastBirthdayYear: 0,
     };
   },
+  // Sprint 26: add peakWizardFame tracking.
+  16: (s: unknown) => {
+    const state = s as Record<string, unknown>;
+    return { ...state, peakWizardFame: 0 };
+  },
 };
 
 function migrate(data: SaveData): GameState {

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -214,6 +214,7 @@ export interface GameState {
   intelligence: number;       // learning speed at university; degrades with age
   bookbinding: number;        // spellbook capacity
   wizardFame: number;         // unlocks, loan caps, event chances
+  peakWizardFame: number;     // Sprint 26: highest wizardFame reached this run
   relaxationRate: number;     // passive chill restore rate
   restingRelaxation: number;  // baseline chill target
 

--- a/src/ui/screens/game-over.ts
+++ b/src/ui/screens/game-over.ts
@@ -1,14 +1,42 @@
-// Game Over screen — shown when the player can't pay rent (evicted).
-// Displays final cash, days survived, best single win.
-// A NEW GAME button resets the run.
+// Legacy Screen (Sprint 26) — shown when the player can't pay rent (evicted).
+// Displays a programmatically generated life summary: final score, age at death,
+// highest Wizard Fame, best single win, most/least favored gods, total tickets
+// scratched, and notable Random Events experienced.
 
-import type { GameState } from '../../state/types';
+import type { GameState, GodId } from '../../state/types';
 import type { GameAction } from '../../engine/actions';
 import { makeButton, makeHeader, makeDivider, makeResultLine } from '../components';
 import { formatCash } from '../../util/format';
 import { calcDaysSurvived } from '../../systems/rent';
+import { getEventDef } from '../../data/events';
 
 type Dispatch = (action: GameAction) => void;
+
+// Score formula: rewards longevity, big wins, fame, and activity.
+function calcFinalScore(state: GameState): number {
+  const days = calcDaysSurvived(state.day, state.month, state.year);
+  return (
+    days * 10 +
+    Math.floor(state.bestSingleWin) +
+    state.peakWizardFame * 20 +
+    state.totalTicketsScratched * 2
+  );
+}
+
+// Return [mostFavoredName, leastFavoredName] from affinity record.
+// Returns 'none' if all values are 0.
+function getFavoredGods(affinity: Record<GodId, number>): [string, string] {
+  const entries = Object.entries(affinity) as [GodId, number][];
+  if (entries.every(([, v]) => v === 0)) return ['none', 'none'];
+  const sorted = [...entries].sort((a, b) => b[1] - a[1]);
+  const mostFavored = capitalize(sorted[0][0]);
+  const leastFavored = capitalize(sorted[sorted.length - 1][0]);
+  return [mostFavored, leastFavored];
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
 
 export function renderGameOver(state: GameState, container: HTMLElement, dispatch: Dispatch): void {
   container.innerHTML = '';
@@ -16,7 +44,7 @@ export function renderGameOver(state: GameState, container: HTMLElement, dispatc
   const screen = document.createElement('div');
   screen.className = 'screen game-over-screen';
 
-  screen.appendChild(makeHeader('GAME OVER'));
+  screen.appendChild(makeHeader("WIZARD'S LEGACY"));
   screen.appendChild(makeDivider());
 
   const msg = document.createElement('p');
@@ -26,11 +54,45 @@ export function renderGameOver(state: GameState, container: HTMLElement, dispatc
 
   screen.appendChild(makeDivider());
 
+  // Final score
+  const score = calcFinalScore(state);
+  screen.appendChild(makeResultLine(`SCORE:           ${score}`));
+
+  screen.appendChild(makeDivider());
+
+  // Run stats
   const days = calcDaysSurvived(state.day, state.month, state.year);
-  screen.appendChild(makeResultLine(`Days:    ${days}`));
-  screen.appendChild(makeResultLine(`Cash:    ${formatCash(state.cash)}`));
+  screen.appendChild(makeResultLine(`Age:             Year ${state.year}`));
+  screen.appendChild(makeResultLine(`Days survived:   ${days}`));
+  screen.appendChild(makeResultLine(`Tickets:         ${state.totalTicketsScratched}`));
   if (state.bestSingleWin > 0) {
-    screen.appendChild(makeResultLine(`Best:    ${formatCash(state.bestSingleWin)}`));
+    screen.appendChild(makeResultLine(`Best win:        ${formatCash(state.bestSingleWin)}`));
+  }
+  screen.appendChild(makeResultLine(`Peak fame:       ${state.peakWizardFame}`));
+
+  screen.appendChild(makeDivider());
+
+  // God affinity summary
+  const [mostFavored, leastFavored] = getFavoredGods(state.affinity);
+  screen.appendChild(makeResultLine(`Most favored:    ${mostFavored}`));
+  screen.appendChild(makeResultLine(`Least favored:   ${leastFavored}`));
+
+  screen.appendChild(makeDivider());
+
+  // Notable events
+  const eventsHeader = document.createElement('p');
+  eventsHeader.className = 'result-line';
+  eventsHeader.textContent = 'EVENTS WITNESSED';
+  screen.appendChild(eventsHeader);
+
+  if (state.notableEvents.length === 0) {
+    screen.appendChild(makeResultLine('  None'));
+  } else {
+    for (const eventId of state.notableEvents) {
+      let name = eventId;
+      try { name = getEventDef(eventId).name; } catch { /* unknown event id */ }
+      screen.appendChild(makeResultLine(`  \u00b7 ${name}`));
+    }
   }
 
   screen.appendChild(makeDivider());


### PR DESCRIPTION
Adds peakWizardFame tracking (saved, migrated, updated via dispatch
post-processing) and rewrites the game-over screen to show: final score,
age at death, days survived, total tickets, best win, peak Wizard Fame,
most/least favored gods, and notable random events experienced. SAVE_VERSION
bumped to 17 with migration 16→17.

https://claude.ai/code/session_01KASGVK5AGXKvXoCPQEQnfB