### PR TITLE
Sprint 27: Color scheme toggle — bump save version and add migration

### DIFF
--- a/src/state/initial.ts
+++ b/src/state/initial.ts
@@ -1,7 +1,7 @@
 import type { GameState } from './types';
 import balance from '../data/balance.json';
 
-export const SAVE_VERSION = 17;
+export const SAVE_VERSION = 18;
 
 export function createInitialState(): GameState {
   return {

--- a/src/state/save.ts
+++ b/src/state/save.ts
@@ -135,6 +135,11 @@ const MIGRATIONS: Record<number, (s: unknown) => unknown> = {
     const state = s as Record<string, unknown>;
     return { ...state, peakWizardFame: 0 };
   },
+  // Sprint 27: add colorScheme preference (default blue; preserve if already present).
+  17: (s: unknown) => {
+    const state = s as Record<string, unknown>;
+    return { ...state, colorScheme: state['colorScheme'] ?? 'blue' };
+  },
 };
 
 function migrate(data: SaveData): GameState {

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -9,10 +9,12 @@ export function applyTheme(scheme: ColorScheme): void {
 // Load persisted theme and apply it. Returns the scheme in use.
 export function initTheme(stateScheme: ColorScheme): ColorScheme {
   const saved = loadTheme();
-  const scheme =
+  const scheme: ColorScheme =
     saved === 'blue' || saved === 'green' || saved === 'orange'
       ? saved
-      : stateScheme;
+      : stateScheme === 'blue' || stateScheme === 'green' || stateScheme === 'orange'
+        ? stateScheme
+        : 'blue';
   applyTheme(scheme);
   return scheme;
 }


### PR DESCRIPTION
- Bump SAVE_VERSION 17 → 18 (colorScheme field now has a proper migration)
- Add migration 17: preserves existing colorScheme or defaults to 'blue'
- Harden initTheme() with fallback to 'blue' when stateScheme is invalid

The toggle UI, CSS themes, SET_THEME dispatch handler, and theme
persistence via localStorage were already wired up. This sprint
completes the feature by ensuring old saves migrate cleanly.

https://claude.ai/code/session_01CExzQsD6nqLyfJ7kV7qxRi