### PR TITLE
Code review: typed balance, DOM cleanup, lint, docs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,23 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-non-null-assertion": "warn",
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+    "no-fallthrough": "error",
+    "eqeqeq": ["error", "always"],
+    "no-var": "error",
+    "prefer-const": "error"
+  },
+  "ignorePatterns": ["dist/", "node_modules/"]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,98 +14,125 @@ Always read `scope.md` before implementing any mechanic. If something isn't in s
 
 ## Implementation Notes (for sprint continuity)
 
+### Balance Data Access
+- All tuning constants live in `src/data/balance.json`
+- **Always import `bal` from `src/data/balance-types.ts`** — never import `balance.json` directly
+- `balance-types.ts` provides full TypeScript type safety via the `BalanceData` interface
+- To add a new balance field: add the interface field in `balance-types.ts`, add the value in `balance.json`
+
 ### Save System
-- Current `SAVE_VERSION`: 14 (as of Sprint 19)
+- Current `SAVE_VERSION`: 18 (in `src/state/initial.ts`)
 - Migrations are in `src/state/save.ts`, keyed by source version (e.g. `3:` migrates v3→v4)
 - Every sprint that adds fields to `GameState` must bump `SAVE_VERSION` in `src/state/initial.ts` and add a migration
+- Update the SAVE_VERSION assertion in test files when bumping
 
 ### State & Systems Pattern
 - All game state lives in the flat `GameState` interface in `src/state/types.ts`
 - Systems are pure functions in `src/systems/*.ts` — no side effects, no held state
 - Action dispatch flows through `src/engine/dispatch.ts` → systems → `src/ui/renderer.ts`
-- `src/data/balance.json` holds all tuning constants — never hardcode gameplay numbers in code
+- See the guide comment at the top of `dispatch.ts` for how to add new actions
+
+### Calendar & Time Constants
+- Shared constants in `src/engine/time.ts`: `MINUTES_PER_QUARTER`, `MINUTES_PER_DAY`, `DAYS_PER_MONTH`, `MONTHS_PER_YEAR`, `DAYS_PER_YEAR`
+- Use `toTotalMinutes()` from `src/engine/time.ts` for all timestamp comparisons (never reimplement inline)
+- Use `advanceClock()` for all clock advancement; it handles :15 snapping automatically
 
 ### HUD Layout
-- HUD is two rows: Row 1 = cash/clock/date, Row 2 = meter bars (chill, future: mana)
+- HUD is two rows: Row 1 = cash/clock/date, Row 2 = meter bars (chill, mana)
 - CSS class `.hud-row` for the info row, `.hud-bars` for the meters row
 - Use `progressBar()` from `src/util/format.ts` for all text-based bars
 
+### DOM Rendering
+- All screen render functions use `container.replaceChildren()` to clear content (never `innerHTML = ''`)
+- All DOM creation uses `createElement` + `textContent` — no innerHTML string injection
+- HUD uses `el.replaceChildren(row1, row2)` for atomic updates
+
 ### Passout System
 - `applyPassout()` in `src/engine/time.ts` handles all passout effects
-- Uses per-neighborhood entries from `balance.passout` with `cashPenalty`, `chillRestore`, `manaRestore`
+- Uses per-neighborhood entries from `bal.passout` with `cashPenalty`, `chillRestore`, `manaRestore`
 - Chill set to `chillRestore * 100`, mana set to `manaRestore * maxMana`
 
 ### Chill Meter (Sprint 5+)
 - `chill` field on GameState, starts at 50, floor 0, no hard cap
 - Decreases on scratch losses, increases on scratch wins (both in `scratchCell()`)
 - Set to `chillRestore * 100` on passout
-- Sprint 7: snacks restore chill via `CONSUME_SNACK` action (amounts in `balance.snacks.chillRestore`)
-- No passive time-based decay, no sleep restore, no bong restore yet
+- Sprint 7: snacks restore chill via `CONSUME_SNACK` action (amounts in `bal.snacks.chillRestore`)
+- Sprint 13: bong restores chill (`bal.chill.bongRestoreAmount`)
 
 ### Mana Pool (Sprint 6)
 - `mana` and `maxMana` fields on GameState, starts at 20/30
-- Restores on sleep by flat `balance.mana.sleepManaRestore` (15), capped at maxMana
-- Set to `manaRestore * maxMana` on passout (per-neighborhood ratios in balance.passout)
-- No spells, no mana spending yet — resource pool only for Sprint 9+
+- Restores on sleep based on bed quality (`bal.furniture.beds[bedId]`), capped at maxMana
+- Set to `manaRestore * maxMana` on passout (per-neighborhood ratios in `bal.passout`)
 - Pure functions in `src/systems/mana.ts`: `applyManaSpend()`, `applyManaRestore()`
 
 ### Inventory & Snacks (Sprint 7)
 - `inventory` field on GameState: `(InventoryItem | null)[]`, length 5
 - Pure functions in `src/systems/inventory.ts`: `freeSlots()`, `addItem()`, `removeItem()`, `addMultipleItems()`
 - Snack definitions in `src/data/food.ts` with 6 descriptors: greasy, salty, sugary, bland, healthy, gourmet
-- Chill restore per descriptor in `balance.snacks.chillRestore`
-- `BUY_TICKETS` action extended with optional `snacks` array; `CONSUME_SNACK` action for eating
-- Consuming is instant (no time cost); buying at bodega is part of the store visit
-- Inventory panel (`makeInventoryPanel` in `components.ts`) shown on tower and bodega screens
-- No item stacking, no health/aging impact yet (Sprint 18), no god affinities on food yet
+- Chill restore per descriptor in `bal.snacks.chillRestore`
+- Shared helper `addSnacksToInventory()` in `dispatch.ts` handles snack→inventory conversion (used by BUY_TICKETS and ORDER_DRINK)
 
-### God Affinity & Temples (Sprint 9)
-- Current `SAVE_VERSION`: 8
+### God Affinity & Temples (Sprint 9+)
 - `affinity: Record<GodId, number>` and `prayerBuffs: PrayerBuff[]` fields on GameState
 - 10 gods defined in `src/data/gods.ts` with opposition circle (`OPPOSITION` record)
 - 10 temple locations (1 per god) across 6 neighborhoods in `src/data/locations.ts`
-- `LocationType` now includes `'temple'`; `LocationData` has optional `godId` for temples
-- Pure functions in `src/systems/affinity.ts`: `applyDonation()`, `hasPrayerBuff()`, `pruneExpiredBuffs()`, `createPrayerBuff()`
-- Donation math: `gain = amount * scaleFactor * donationTypeMultiplier`; opposed god loses same amount; prayer buffs modify gain (2x) and loss (0.5x)
-- Prayer advances clock, restores mana (`balance.prayer.manaRestorePerQuarter` per 15 min), creates timed buff
-- Actions: `DONATE_PRIVATE`, `DONATE_PUBLIC`, `PRAY` — god inferred from `state.currentLocation`
-- Temple screen in `src/ui/screens/temple.ts`; tower/bodega travel sections include temple buttons
-- No affinity effects on scratchers yet (Sprint 10), no strong month multipliers (Sprint 11), no passive decay (Sprint 12)
+- Pure functions in `src/systems/affinity.ts`: `applyDonation()`, `hasPrayerBuff()`, `pruneExpiredBuffs()`, `createPrayerBuff()`, `applyAffinityDecay()`
+- `addMinutesToTimestamp()` exported from `affinity.ts` for prayer buff expiry calculation
+- Sprint 12: `applyAffinityDecay()` called daily during SLEEP action
+- Sprint 24: neighborhood dominant gods boost affinity gain and symbol frequency
 
 ### Wizard Tower & Furniture (Sprint 13)
-- Current `SAVE_VERSION`: 10
-- `furniture: FurnitureItem[]` field on GameState (max 10 slots, from `balance.furniture.maxSlots`)
-- `FurnitureItem` interface: `{ type: FurnitureType, id: string, name: string, quality: number }`
-- `FurnitureType = 'bed' | 'lab_table' | 'bong'`
-- Furniture catalog in `src/data/furniture.ts`: 3 bed tiers, 1 lab table, 1 bong
-- Pure functions in `src/systems/furniture.ts`: `getBed()`, `addFurniture()`, `removeFurniture()`, `replaceBed()`, `findBong()`, `hasLabTable()`
-- Bed quality determines sleep mana/chill restore (values in `balance.furniture.beds[bedId]`)
-- Beds swap on upgrade: buying a better bed replaces the existing one (only 1 bed at a time)
-- Bong restores chill (`balance.chill.bongRestoreAmount`) with break chance (`balance.furniture.bong.breakChance`); broken bong is silently removed (Random Events in Sprint 23)
-- Lab Table is placeholder only — no interaction until Sprint 20
-- `LocationType` now includes `'furniture_store'`; 6 furniture stores (one per neighborhood)
-- Actions: `BUY_FURNITURE`, `USE_BONG`, `RECYCLE_FURNITURE`
-- Furniture store screen in `src/ui/screens/furniture-store.ts`
-- Tower screen shows furniture panel with USE (bong) and RECYCLE buttons; sleep gated on having a bed
+- `furniture: FurnitureItem[]` field on GameState (max 10 slots, from `bal.furniture.maxSlots`)
+- `FurnitureType = 'bed' | 'lab_table' | 'bong' | 'crystal_ball'`
+- Furniture catalog in `src/data/furniture.ts`: 3 bed tiers, 1 lab table, 1 bong, 1 crystal ball
+- Pure functions in `src/systems/furniture.ts`: `getBed()`, `addFurniture()`, `removeFurniture()`, `replaceBed()`, `findBong()`, `hasLabTable()`, `hasCrystalBall()`
+- Bed quality determines sleep mana/chill restore (values in `bal.furniture.beds[bedId]`)
+- Bong restores chill with break chance; broken bong triggers `bong_breaks` random event (Sprint 23)
 - Tower starts with one basic Bed ("Dusty Mattress", quality 1)
-- No Wizard Projects via Lab Table yet (Sprint 20)
+
+### Spellbook & Casting (Sprint 14-16)
+- `knownSpells: string[]`, `equippedSpells: string[]`, `luckBuff: LuckBuff | null`
+- 11 spells in `src/data/spells.ts` across 7 categories
+- Per-spell balance data in `bal.spells` (typed via `SpellBalance` interface)
+- Misfire chance: `baseMisfireChance + max(0, 50 − chill) × chillMisfireScaling` (in `calcMisfireChance()`)
+- `applySpellEffect()` in `dispatch.ts` handles all spell effects by category
+- Sprint 22: spellbook locked as loan collateral (`isSpellbookLocked()` in `loan.ts`)
+
+### Addiction (Sprint 17)
+- `addictionNeed` and `addictionSatisfaction` hidden stats on GameState
+- Grows on ticket purchase, satisfaction on session finish (in `src/systems/addiction.ts`)
+- Affects `restingRelaxation` via `computeRestingRelaxation()`
 
 ### Crystal Ball & Hidden Stats (Sprint 19)
-- Current `SAVE_VERSION`: 14
-- `crystalBallReveal: { stat: string; label: string; value: number } | null` — transient field on GameState, cleared on every action in `dispatch.ts`
-- `ageHealthScore: number` added to GameState (starts at 100, stub for Sprint 18 aging system)
-- Crystal Ball is singleton furniture (`crystal_ball` type), sold at all furniture stores
-- `USE_CRYSTAL_BALL` action takes `revealType: 'addiction' | 'chill' | 'ageHealth'`
-- Reveal spells are gate-checked via `knownSpells` (not `equippedSpells`) — learning the spell is the gate
-- Three reveal spells: `true_sight` (L1, reveals Chill), `inner_eye` (L2, reveals Addiction), `vital_scan` (L2, reveals Age Health)
-- Mana cost from `balance.crystalBall.revealManaCost` (flat, per use); no time cost (instant)
-- Crystal Ball panel in tower shows [GAZE] buttons per known reveal spell, with result display
-- Pure function `hasCrystalBall()` in `src/systems/furniture.ts`
-- No Crystal Ball effects on scratchers or other systems yet
+- `crystalBallReveal` transient field cleared on every action in `dispatch.ts`
+- `USE_CRYSTAL_BALL` action gate-checks via `knownSpells` (learning is the gate)
+- Three reveal spells: `true_sight` (Chill), `inner_eye` (Addiction), `vital_scan` (Age Health)
+- Mana cost from `bal.crystalBall.revealManaCost`
+
+### Wizard Projects (Sprint 20-21)
+- `activeProject: ProjectState | null` on GameState
+- Project definitions in `src/data/projects.ts`, balance in `bal.projects`
+- Pure functions in `src/systems/projects.ts`: `startProject()`, `workOnProject()`, `cancelProject()`, `collectProject()`
+
+### Dad's House & Loans (Sprint 22)
+- `dadAlive`, `loan: LoanState | null` on GameState
+- Loan system in `src/systems/loan.ts`: `takeLoan()`, `repayLoan()`, `accrueInterest()`
+- Balance in `bal.dadsHouse`
+
+### Random Events (Sprint 23)
+- 12 events in `src/data/events.ts`, balance in `bal.randomEvents`
+- Pure functions in `src/systems/events.ts`: `checkForEvent()`, `createActiveEvent()`, `resolveEvent()`
+- Events trigger after most actions when in 'playing' phase
+- Loan shark debt tracked separately: `loanSharkDebt`, `loanSharkInterestRate`
+
+### Bar (Sprint 25)
+- Drink definitions in `src/data/drinks.ts`, balance in `bal.bar.drinks`
+- `ORDER_DRINK` action supports optional snack purchase (uses shared `addSnacksToInventory()`)
 
 ## Stack
 
 - Mobile-first browser game (no native app)
+- TypeScript + Vite, Vitest for testing, ESLint for linting
 - No backend required at this stage
 - No AI-generated text or art — ever
 - No external assets; all visuals are text/Unicode glyphs only (CP437 / BMP only — see scope.md Symbol Set)
@@ -117,6 +144,9 @@ Always read `scope.md` before implementing any mechanic. If something isn't in s
 - **All tasks snap to :15 increments** (:00, :15, :30, :45) except scratch sessions, which use their own timing (15s/ticket, 1 min minimum, then snap).
 - **No art.** If a feature seems to need an image, find a CP437/Unicode glyph solution instead.
 - **Consult scope.md for all god affinity math, symbol assignments, and opposition circle logic** before implementing any of those systems.
+- **Use `bal` from `balance-types.ts`** for all balance data access. Never import `balance.json` directly.
+- **Use `toTotalMinutes()` from `time.ts`** for timestamp comparisons. Never reimplement locally.
+- **Use `container.replaceChildren()`** to clear DOM elements. Never use `innerHTML = ''`.
 
 ## Style
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -407,6 +407,7 @@ All UI elements reference custom properties. Theme toggle swaps `data-theme` on 
 │   │   └── events.ts              # Random event trigger and resolution
 │   ├── data/
 │   │   ├── balance.json           # All tuning values (see Section 8)
+│   │   ├── balance-types.ts      # Typed interface for balance.json (import `bal` from here)
 │   │   ├── gods.ts                # God definitions, opposition circle
 │   │   ├── symbols.ts             # 30 symbols, element/god/strength mapping
 │   │   ├── neighborhoods.ts       # 6 neighborhoods, god strengths
@@ -549,20 +550,21 @@ All gameplay-affecting numbers live in a single human-readable JSON file. This i
 ### How it works in code
 
 ```typescript
-import balance from './data/balance.json';
+import { bal } from './data/balance-types';
 
-// Systems reference balance values, never hardcode numbers
+// Systems reference balance values via the typed `bal` object — never
+// import balance.json directly and never hardcode numbers.
 function calculateChillDecay(elapsedMinutes: number): number {
-  return elapsedMinutes * balance.chill.decayPerMinute;
+  return elapsedMinutes * bal.chill.decayPerMinute;
 }
 
 function calculateAffinityPayout(basePayout: number, affinity: number): number {
-  const multiplier = 1 + (affinity * balance.affinity.scaleFactor);
+  const multiplier = 1 + (affinity * bal.affinity.scaleFactor);
   return Math.floor(basePayout * multiplier);
 }
 ```
 
-New tuning values are added to this file as systems are built. The file grows with each sprint but never needs restructuring.
+All balance access goes through the typed `bal` export from `src/data/balance-types.ts`. This gives compile-time checking for every balance key — a typo or renamed field causes a TypeScript error instead of a silent runtime bug. New tuning values are added to `balance.json` and the matching interface in `balance-types.ts` as systems are built.
 
 ---
 

--- a/src/data/balance-types.ts
+++ b/src/data/balance-types.ts
@@ -1,0 +1,291 @@
+// Typed interface for balance.json — single source of truth for all balance data access.
+// Import `bal` from this module instead of importing balance.json directly.
+//
+// To add a new balance field:
+// 1. Add the field to the appropriate interface below
+// 2. Add the value to balance.json
+// 3. Import `bal` and access it with full type safety — no casts needed
+
+import _balance from './balance.json';
+
+// ─── Sub-interfaces ──────────────────────────────────────────────────────────
+
+export interface StartingBalance {
+  cash: number;
+  neighborhood: string;
+  chill: number;
+  mana: number;
+  maxMana: number;
+  intelligence: number;
+  bookbinding: number;
+  wizardFame: number;
+  relaxationRate: number;
+  restingRelaxation: number;
+  ageHealthScore: number;
+}
+
+export interface RentBalance {
+  amount: number;
+  dueDay: number;
+}
+
+export interface DayCycleBalance {
+  wakeTime: number;
+  curfewTime: number;
+  sleepChillRestore: string;
+  sleepManaRestore: string;
+}
+
+export interface TravelBalance {
+  sameNeighborhoodMinutes: number;
+  crossNeighborhoodMinutes: number;
+}
+
+export interface ScratchingBalance {
+  secondsPerTicket: number;
+  minimumSessionSeconds: number;
+}
+
+export interface PassoutEntry {
+  cashPenalty: number;
+  chillRestore: number;
+  manaRestore: number;
+}
+
+export interface ChillBalance {
+  decayPerMinute: number;
+  lossPerScratchLoss: number;
+  gainPerScratchWin: number;
+  bongRestoreAmount: number;
+}
+
+export interface ManaBalance {
+  passoutPenalty: number;
+  sleepManaRestore: number;
+}
+
+export interface SnacksBalance {
+  chillRestore: Record<string, number>;
+}
+
+export interface PrayerBalance {
+  manaRestorePerQuarter: number;
+  donationAmounts: number[];
+  durationOptions: number[];
+}
+
+export interface AffinityBalance {
+  scaleFactor: number;
+  privateDonationMultiplier: number;
+  publicDonationMultiplier: number;
+  publicDonationFameGain: number;
+  strongMonthMultiplier: number;
+  passiveDecayPerDay: number;
+  prayerBuffMultiplier: number;
+  prayerDebuffMultiplier: number;
+  payoutAffinityScale: number;
+  payoutMultiplierFloor: number;
+}
+
+export interface AddictionBalance {
+  needGrowthRate: number;
+  satisfactionPerTicket: number;
+  restingRelaxationPenaltyPerLevel: number;
+}
+
+export interface AgingBalance {
+  intelligenceDecayPerYear: number;
+  addictionSusceptibilityPerYear: number;
+  baseDeathAge: number;
+  healthScoreDeathAgeBonus: number;
+}
+
+export interface WizardFameBalance {
+  decayPerDay: number;
+}
+
+export interface BedBalance {
+  cost: number;
+  sleepMana: number;
+  sleepChill: number;
+}
+
+export interface FurnitureBalance {
+  maxSlots: number;
+  beds: Record<string, BedBalance>;
+  lab_table: { cost: number };
+  bong: { cost: number; breakChance: number };
+  crystal_ball: { cost: number };
+}
+
+export interface CrystalBallBalance {
+  revealManaCost: number;
+}
+
+export interface StatsBalance {
+  displayMax: {
+    intelligence: number;
+    bookbinding: number;
+    wizardFame: number;
+    relaxationRate: number;
+    restingRelaxation: number;
+  };
+}
+
+export interface UniversityBalance {
+  openTime: number;
+  closeTime: number;
+  classesPerDay: number;
+  bookbindingCost: number;
+  bookbindingTime: number;
+  bookbindingMana: number;
+  intelligenceSpeedFactor: number;
+}
+
+export interface SpellbookBalance {
+  addTimeMultiplier: number;
+  removeTimeMultiplier: number;
+}
+
+export interface ScrollsBalance {
+  priceByLevel: Record<string, number>;
+  bookstoreMarkup: number;
+  storePurchaseTimeCost: number;
+}
+
+export interface ProjectDefinitionBalance {
+  requiredProgress: number;
+}
+
+export interface ProjectsBalance {
+  chillCostPerQuarter: number;
+  lowChillThreshold: number;
+  lowChillProgressMultiplier: number;
+  baseProgressPerQuarter: number;
+  durationOptions: number[];
+  definitions: Record<string, ProjectDefinitionBalance>;
+}
+
+export interface MonumentDonationEntry {
+  affinityGain: number;
+  opposedLoss: number;
+}
+
+export interface MonumentDonationBalance {
+  small: MonumentDonationEntry;
+  medium: MonumentDonationEntry;
+  large: MonumentDonationEntry;
+}
+
+export interface SpellBalance {
+  baseMisfireChance: number;
+  // Spell-specific fields (each spell has different optional fields)
+  affinityGain?: number;
+  affinityLoss?: number;
+  winChanceBonus?: number;
+  durationMinutes?: number;
+  chillRestore?: number;
+  manaRestore?: number;
+  reveals?: string;
+}
+
+export interface SpellsBalance {
+  favor_boost: SpellBalance;
+  divine_slight: SpellBalance;
+  lucky_fingers: SpellBalance & { winChanceBonus: number; durationMinutes: number };
+  stacked_deck: SpellBalance & { winChanceBonus: number; durationMinutes: number };
+  mellow_wave: SpellBalance & { chillRestore: number };
+  deep_calm: SpellBalance & { chillRestore: number };
+  mana_siphon: SpellBalance & { manaRestore: number };
+  inner_eye: SpellBalance & { reveals: string };
+  true_sight: SpellBalance & { reveals: string };
+  vital_scan: SpellBalance & { reveals: string };
+  chillMisfireScaling: number;
+  [key: string]: SpellBalance | number;
+}
+
+export interface DadsHouseBalance {
+  loanAmounts: number[];
+  collateralThreshold: number;
+  baseInterestRate: number;
+  fameInterestReduction: number;
+  minInterestRate: number;
+  baseLoanCap: number;
+  fameCapBonus: number;
+  maxLoanCap: number;
+  visitTimeCost: number;
+  graveManaRestore: number;
+  graveChillLoss: number;
+}
+
+export interface NeighborhoodGodStrengthBalance {
+  affinityGainMultiplier: number;
+  symbolWeightBonus: number;
+}
+
+export interface DrinkBalance {
+  cost: number;
+  timeMinutes: number;
+  chillRestore: number;
+  manaReduction: number;
+}
+
+export interface BarBalance {
+  drinks: Record<string, DrinkBalance>;
+}
+
+export interface RandomEventBalance {
+  [key: string]: number;
+}
+
+export interface RandomEventsBalance {
+  birthday: RandomEventBalance;
+  dad_dies: RandomEventBalance;
+  bong_breaks: RandomEventBalance;
+  suspicious_clerk: RandomEventBalance;
+  fellow_scratcher: RandomEventBalance;
+  temple_judgment: RandomEventBalance;
+  campus_encounter: RandomEventBalance;
+  loan_shark: RandomEventBalance;
+  storm_warning: RandomEventBalance;
+  winning_ticket: RandomEventBalance;
+  wizard_fame_moment: RandomEventBalance;
+  bad_batch: RandomEventBalance;
+}
+
+// ─── Top-level Balance Interface ─────────────────────────────────────────────
+
+export interface BalanceData {
+  starting: StartingBalance;
+  rent: RentBalance;
+  dayCycle: DayCycleBalance;
+  travel: TravelBalance;
+  scratching: ScratchingBalance;
+  passout: Record<string, PassoutEntry>;
+  chill: ChillBalance;
+  mana: ManaBalance;
+  snacks: SnacksBalance;
+  prayer: PrayerBalance;
+  affinity: AffinityBalance;
+  addiction: AddictionBalance;
+  aging: AgingBalance;
+  wizardFame: WizardFameBalance;
+  furniture: FurnitureBalance;
+  crystalBall: CrystalBallBalance;
+  stats: StatsBalance;
+  university: UniversityBalance;
+  spellbook: SpellbookBalance;
+  scrolls: ScrollsBalance;
+  projects: ProjectsBalance;
+  monumentDonation: MonumentDonationBalance;
+  spells: SpellsBalance;
+  dadsHouse: DadsHouseBalance;
+  neighborhoodGodStrength: NeighborhoodGodStrengthBalance;
+  bar: BarBalance;
+  randomEvents: RandomEventsBalance;
+}
+
+// ─── Typed Export ─────────────────────────────────────────────────────────────
+
+/** Typed balance data — import this instead of balance.json directly. */
+export const bal = _balance as unknown as BalanceData;

--- a/src/data/drinks.ts
+++ b/src/data/drinks.ts
@@ -1,7 +1,7 @@
 // Drink definitions for the University Bar (Sprint 25).
 // Values sourced from balance.json — never hardcode gameplay numbers here.
 
-import balance from './balance.json';
+import { bal } from './balance-types';
 
 export interface DrinkDefinition {
   id: string;
@@ -12,9 +12,7 @@ export interface DrinkDefinition {
   manaReduction: number;
 }
 
-type BarDrinkBalance = { cost: number; timeMinutes: number; chillRestore: number; manaReduction: number };
-
-const barBal = (balance as Record<string, unknown>).bar as { drinks: Record<string, BarDrinkBalance> };
+const barBal = bal.bar;
 
 export const DRINKS: DrinkDefinition[] = [
   {

--- a/src/data/furniture.ts
+++ b/src/data/furniture.ts
@@ -2,7 +2,7 @@
 // Sprint 13: Bed (3 tiers), Lab Table (placeholder), Bong.
 
 import type { FurnitureType } from '../state/types';
-import balance from './balance.json';
+import { bal } from './balance-types';
 
 export interface FurnitureDef {
   id: string;
@@ -12,12 +12,7 @@ export interface FurnitureDef {
   quality: number;
 }
 
-const furnitureBalance = balance.furniture as {
-  beds: Record<string, { cost: number; sleepMana: number; sleepChill: number }>;
-  lab_table: { cost: number };
-  bong: { cost: number; breakChance: number };
-  crystal_ball: { cost: number };
-};
+const furnitureBalance = bal.furniture;
 
 export const FURNITURE_CATALOG: FurnitureDef[] = [
   { id: 'bed_basic',    type: 'bed',       name: 'Dusty Mattress', cost: furnitureBalance.beds.bed_basic.cost,    quality: 1 },

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -3,7 +3,7 @@
 // One active project at a time; canceling loses all progress.
 // Completed projects produce inventory items.
 
-import balance from './balance.json';
+import { bal } from './balance-types';
 
 export type ProjectId =
   | 'longevity_potion'
@@ -25,7 +25,7 @@ export interface ProjectDef {
   };
 }
 
-const defs = (balance as any).projects.definitions;
+const defs = bal.projects.definitions;
 
 export const PROJECTS: ProjectDef[] = [
   {

--- a/src/data/spells.ts
+++ b/src/data/spells.ts
@@ -1,7 +1,7 @@
 // Spell definitions — the full spell catalog.
 // Sprint 14: metadata only; spell effects are wired in Sprint 15.
 
-import balance from './balance.json';
+import { bal } from './balance-types';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -205,14 +205,10 @@ export function getSpellsByCategory(category: SpellCategory): SpellDef[] {
 // Bookbinding is learned at the university like a spell, but it's a skill.
 // Cost/time/mana come from balance.json → university section.
 
-const universityBal = (balance as Record<string, unknown>).university as {
-  bookbindingCost: number;
-  bookbindingTime: number;
-  bookbindingMana: number;
-} | undefined;
+const universityBal = bal.university;
 
 export const BOOKBINDING_CLASS = {
-  cost: universityBal?.bookbindingCost ?? 75,
-  baseTime: universityBal?.bookbindingTime ?? 30,
-  mana: universityBal?.bookbindingMana ?? 8,
+  cost: universityBal.bookbindingCost,
+  baseTime: universityBal.bookbindingTime,
+  mana: universityBal.bookbindingMana,
 };

--- a/src/engine/dispatch.ts
+++ b/src/engine/dispatch.ts
@@ -1,5 +1,17 @@
 // Central action dispatcher.
 // Every player action flows through here: validate → apply → save → render.
+//
+// ─── How to add a new action ──────────────────────────────────────────────────
+// 1. Add the action type to the GameAction union in actions.ts
+// 2. Add a case to the switch in applyAction() below
+// 3. Follow the validation pattern: check phase, location, and resources first
+// 4. If the action advances the clock, call advanceClock() and check
+//    isCurfewBreached() → applyPassout() before applying effects
+// 5. If it adds fields to GameState, bump SAVE_VERSION in initial.ts
+//    and add a migration in save.ts
+// 6. Use bal.X for balance data (never import balance.json directly)
+// 7. Use toTotalMinutes() from time.ts for timestamp comparisons
+// ──────────────────────────────────────────────────────────────────────────────
 
 import type { GameState } from '../state/types';
 import type { GameAction } from './actions';
@@ -14,7 +26,7 @@ import {
 } from '../systems/scratch';
 import { travel } from '../systems/travel';
 import { checkRent } from '../systems/rent';
-import { advanceDay, applyPassout, isCurfewBreached, advanceClock } from './time';
+import { advanceDay, applyPassout, isCurfewBreached, advanceClock, toTotalMinutes } from './time';
 import { calcScratchTimeCost } from '../util/format';
 import { applyManaRestore } from '../systems/mana';
 import { applyChillGain } from '../systems/chill';
@@ -49,12 +61,25 @@ import { getLocationType } from '../data/locations';
 import { checkForEvent, createActiveEvent, resolveEvent, applyLoanSharkInterest, collectLoanSharkDebt } from '../systems/events';
 import { RANDOM_EVENTS } from '../data/events';
 import { getDrink } from '../data/drinks';
-import balance from '../data/balance.json';
+import { bal, type SpellBalance } from '../data/balance-types';
 
 // ─── Spell balance reference ──────────────────────────────────────────────────
-const spellsBal = (balance as Record<string, unknown>).spells as Record<string, unknown> & {
-  lucky_fingers: { winChanceBonus: number; durationMinutes: number; baseMisfireChance: number };
-};
+const spellsBal = bal.spells;
+
+// ─── Shared Helpers ──────────────────────────────────────────────────────────
+
+/** Convert snack IDs into inventory items and add to inventory. */
+function addSnacksToInventory(
+  inventory: GameState['inventory'],
+  snackIds: string[],
+): GameState['inventory'] {
+  if (snackIds.length === 0) return inventory;
+  const items: InventoryItem[] = snackIds.map(id => {
+    const def = getSnack(id);
+    return { type: 'snack' as const, id: def.id, name: def.name, descriptor: def.descriptor };
+  });
+  return addMultipleItems(inventory, items) ?? inventory;
+}
 
 // Applies the category-specific effect of a spell or scroll to an already-clock-advanced,
 // already-mana-spent state. Returns the resulting state.
@@ -71,8 +96,7 @@ function applySpellEffect(
     case 'affinity': {
       if (!godId) break;
 
-      const affData = (spellsBal as Record<string, unknown>)[spellId] as
-        | { affinityGain?: number; affinityLoss?: number } | undefined;
+      const affData = spellsBal[spellId] as SpellBalance | undefined;
 
       const rawChange = affData?.affinityGain ?? (affData?.affinityLoss ? -(affData.affinityLoss) : 0);
       if (rawChange === 0) break;
@@ -82,7 +106,7 @@ function applySpellEffect(
       const hasTargetBuff = hasPrayerBuff(state.prayerBuffs, godId, newClock, state.day, state.month, state.year);
       const hasOpposedBuff = hasPrayerBuff(state.prayerBuffs, opposedGod, newClock, state.day, state.month, state.year);
 
-      const aff = balance.affinity;
+      const aff = bal.affinity;
       const isStrongMonth = getGod(godId).strongMonths.includes(state.month);
       const strongMult = isStrongMonth ? aff.strongMonthMultiplier : 1;
 
@@ -102,8 +126,7 @@ function applySpellEffect(
     }
 
     case 'chill': {
-      const chillData = (spellsBal as Record<string, unknown>)[spellId] as
-        | { chillRestore: number } | undefined;
+      const chillData = spellsBal[spellId] as SpellBalance | undefined;
       if (chillData?.chillRestore) {
         nextState = { ...nextState, chill: applyChillGain(nextState.chill, chillData.chillRestore) };
       }
@@ -111,8 +134,7 @@ function applySpellEffect(
     }
 
     case 'mana': {
-      const manaData = (spellsBal as Record<string, unknown>)[spellId] as
-        | { manaRestore: number } | undefined;
+      const manaData = spellsBal[spellId] as SpellBalance | undefined;
       if (manaData?.manaRestore) {
         nextState = { ...nextState, mana: applyManaRestore(nextState.mana, manaData.manaRestore, nextState.maxMana) };
       }
@@ -120,8 +142,7 @@ function applySpellEffect(
     }
 
     case 'luck': {
-      const luckData = (spellsBal as Record<string, unknown>)[spellId] as
-        | { durationMinutes: number } | undefined;
+      const luckData = spellsBal[spellId] as SpellBalance | undefined;
       if (luckData?.durationMinutes) {
         const expiry = addMinutesToTimestamp(newClock, state.day, state.month, state.year, luckData.durationMinutes);
         const newBuff: LuckBuff = {
@@ -149,9 +170,7 @@ function isLuckBuffActive(
   clock: number, day: number, month: number, year: number,
 ): boolean {
   if (!buff) return false;
-  const toMin = (y: number, mo: number, d: number, c: number) =>
-    y * 360 * 1440 + mo * 30 * 1440 + d * 1440 + c;
-  return toMin(year, month, day, clock) < toMin(buff.expiresInYear, buff.expiresInMonth, buff.expiresOnDay, buff.expiresAtClock);
+  return toTotalMinutes(year, month, day, clock) < toTotalMinutes(buff.expiresInYear, buff.expiresInMonth, buff.expiresOnDay, buff.expiresAtClock);
 }
 
 export type RenderFn = (state: GameState) => void;
@@ -232,20 +251,10 @@ function applyAction(state: GameState, action: GameAction): GameState {
       // Validate inventory space for snacks.
       if (snackIds.length > 0 && !canFitItems(state.inventory, snackIds.length)) return state;
 
-      // Add snacks to inventory.
-      let newInventory = state.inventory;
-      if (snackIds.length > 0) {
-        const items: InventoryItem[] = snackIds.map(id => {
-          const def = getSnack(id);
-          return { type: 'snack' as const, id: def.id, name: def.name, descriptor: def.descriptor };
-        });
-        newInventory = addMultipleItems(state.inventory, items) ?? state.inventory;
-      }
-
       let stateWithPurchase: GameState = {
         ...state,
         cash: state.cash - totalCost,
-        inventory: newInventory,
+        inventory: addSnacksToInventory(state.inventory, snackIds),
       };
 
       // If no tickets, just return (stay on bodega screen — snack-only purchase).
@@ -270,7 +279,7 @@ function applyAction(state: GameState, action: GameAction): GameState {
 
       // Sprint 15: pass luck buff win-chance bonus if active.
       const luckBonus = isLuckBuffActive(stateWithPurchase.luckBuff, newClock, stateWithPurchase.day, stateWithPurchase.month, stateWithPurchase.year)
-        ? (spellsBal.lucky_fingers as { winChanceBonus: number }).winChanceBonus
+        ? spellsBal.lucky_fingers.winChanceBonus
         : 0;
 
       // Sprint 24: pass neighborhood dominant gods to bias symbol frequency.
@@ -322,7 +331,7 @@ function applyAction(state: GameState, action: GameAction): GameState {
       const cal = advanceDay(state.day, state.month, state.year);
       let nextState: GameState = {
         ...state,
-        clock: balance.dayCycle.wakeTime,
+        clock: bal.dayCycle.wakeTime,
         lastPassoutPenalty: null,
         mana: applyManaRestore(state.mana, bedRestore.sleepMana, state.maxMana),
         chill: applyChillGain(state.chill, bedRestore.sleepChill),
@@ -330,13 +339,13 @@ function applyAction(state: GameState, action: GameAction): GameState {
         ...cal,
       };
       // Sprint 22: accrue loan interest on rent day (before rent check).
-      if (nextState.day === balance.rent.dueDay) {
+      if (nextState.day === bal.rent.dueDay) {
         nextState = accrueInterest(nextState);
       }
       // Sprint 23: accrue loan shark interest daily.
       nextState = applyLoanSharkInterest(nextState);
       // Sprint 23: collect loan shark debt on rent day (before rent check).
-      if (nextState.day === balance.rent.dueDay) {
+      if (nextState.day === bal.rent.dueDay) {
         nextState = collectLoanSharkDebt(nextState);
       }
       return checkRent(nextState);
@@ -356,7 +365,7 @@ function applyAction(state: GameState, action: GameAction): GameState {
       const item = state.inventory[action.slotIndex];
       if (!item || item.type !== 'snack') return state;
 
-      const snackBalance = balance.snacks as { chillRestore: Record<string, number> };
+      const snackBalance = bal.snacks;
       const restoreAmount = snackBalance.chillRestore[item.descriptor] ?? 0;
 
       return {
@@ -407,7 +416,7 @@ function applyAction(state: GameState, action: GameAction): GameState {
           state.prayerBuffs, state.clock, state.day, state.month, state.year,
           getNeighborhoodDominantGods(state.currentNeighborhood),
         ),
-        wizardFame: state.wizardFame + balance.affinity.publicDonationFameGain,
+        wizardFame: state.wizardFame + bal.affinity.publicDonationFameGain,
       };
     }
 
@@ -425,7 +434,7 @@ function applyAction(state: GameState, action: GameAction): GameState {
       }
 
       // Mana restore: per-quarter flat amount.
-      const prayerBal = (balance as Record<string, unknown>).prayer as { manaRestorePerQuarter: number };
+      const prayerBal = bal.prayer;
       const quarters = action.duration / 15;
       const newMana = Math.min(state.maxMana, state.mana + quarters * prayerBal.manaRestorePerQuarter);
 
@@ -453,7 +462,7 @@ function applyAction(state: GameState, action: GameAction): GameState {
       const def = getFurnitureDef(action.furnitureId);
       if (state.cash < def.cost) return state;
 
-      const furnitureBalance = balance.furniture as { maxSlots: number };
+      const furnitureBalance = bal.furniture;
       const item: FurnitureItem = {
         type: def.type,
         id: def.id,
@@ -483,8 +492,8 @@ function applyAction(state: GameState, action: GameAction): GameState {
       const item = state.furniture[action.furnitureIndex];
       if (!item || item.type !== 'bong') return state;
 
-      const bongBalance = (balance.furniture as { bong: { breakChance: number } }).bong;
-      const chillRestore = (balance.chill as { bongRestoreAmount: number }).bongRestoreAmount;
+      const bongBalance = bal.furniture.bong;
+      const chillRestore = bal.chill.bongRestoreAmount;
 
       // Restore chill first.
       let nextState: GameState = {
@@ -526,9 +535,7 @@ function applyAction(state: GameState, action: GameAction): GameState {
       if (locData.type !== 'university') return state;
 
       // Check university hours.
-      const uniBal = (balance as Record<string, unknown>).university as {
-        openTime: number; closeTime: number;
-      };
+      const uniBal = bal.university;
       if (state.clock < uniBal.openTime || state.clock >= uniBal.closeTime) return state;
 
       // Already known?
@@ -560,9 +567,7 @@ function applyAction(state: GameState, action: GameAction): GameState {
       const locData = getLocationData(state.currentLocation);
       if (locData.type !== 'university') return state;
 
-      const uniBal = (balance as Record<string, unknown>).university as {
-        openTime: number; closeTime: number;
-      };
+      const uniBal = bal.university;
       if (state.clock < uniBal.openTime || state.clock >= uniBal.closeTime) return state;
 
       if (state.cash < BOOKBINDING_CLASS.cost) return state;
@@ -644,12 +649,11 @@ function applyAction(state: GameState, action: GameAction): GameState {
 
       // ── Sprint 15: misfire check ──────────────────────────────────────────
       // Look up per-spell balance data (may be undefined for spells without effects yet).
-      const spellEntry = (spellsBal as Record<string, unknown>)[action.spellId] as
-        | { baseMisfireChance: number } | undefined;
+      const spellEntry = spellsBal[action.spellId] as SpellBalance | undefined;
       const baseMisfireChance = spellEntry?.baseMisfireChance ?? 0.05;
 
       const misfireChance = calcMisfireChance(baseMisfireChance, state.chill);
-      let [roll, nextSeed] = rng(state.rngSeed);
+      const [roll, nextSeed] = rng(state.rngSeed);
 
       if (roll < misfireChance) {
         // MISFIRE: spell fires but drains twice the mana.
@@ -663,7 +667,7 @@ function applyAction(state: GameState, action: GameAction): GameState {
       }
 
       // ── No misfire: apply spell effect by category ────────────────────────
-      let nextState: GameState = {
+      const nextState: GameState = {
         ...state,
         clock: newClock,
         mana: applyManaSpend(state.mana, spell.manaCost),
@@ -684,11 +688,7 @@ function applyAction(state: GameState, action: GameAction): GameState {
       if (isSpellKnown(state.knownSpells, action.spellId)) return state;
 
       const spell = getSpellDef(action.spellId);
-      const scrollsBal = (balance as Record<string, unknown>).scrolls as {
-        priceByLevel: Record<string, number>;
-        bookstoreMarkup: number;
-        storePurchaseTimeCost: number;
-      };
+      const scrollsBal = bal.scrolls;
       const basePrice = scrollsBal.priceByLevel[String(spell.level)] ?? 50;
       const price = locData.type === 'university_bookstore'
         ? Math.floor(basePrice * scrollsBal.bookstoreMarkup)
@@ -733,8 +733,7 @@ function applyAction(state: GameState, action: GameAction): GameState {
         return applyPassout({ ...state, clock: newClock });
       }
 
-      const spellEntry = (spellsBal as Record<string, unknown>)[item.spellId] as
-        | { baseMisfireChance: number } | undefined;
+      const spellEntry = spellsBal[item.spellId] as SpellBalance | undefined;
       const baseMisfireChance = spellEntry?.baseMisfireChance ?? 0.05;
       const misfireChance = calcMisfireChance(baseMisfireChance, state.chill);
       const [roll, nextSeed] = rng(state.rngSeed);
@@ -788,23 +787,13 @@ function applyAction(state: GameState, action: GameAction): GameState {
         return applyPassout({ ...state, clock: newClock, cash: state.cash - totalCost });
       }
 
-      // Add snacks to inventory.
-      let newInventory = state.inventory;
-      if (snackIds.length > 0) {
-        const items: InventoryItem[] = snackIds.map(id => {
-          const def = getSnack(id);
-          return { type: 'snack' as const, id: def.id, name: def.name, descriptor: def.descriptor };
-        });
-        newInventory = addMultipleItems(state.inventory, items) ?? state.inventory;
-      }
-
       return {
         ...state,
         clock: newClock,
         cash: state.cash - totalCost,
         chill: applyChillGain(state.chill, drink.chillRestore),
         mana: applyManaSpend(state.mana, drink.manaReduction),
-        inventory: newInventory,
+        inventory: addSnacksToInventory(state.inventory, snackIds),
       };
     }
 
@@ -826,7 +815,7 @@ function applyAction(state: GameState, action: GameAction): GameState {
       // Reveal spells use knownSpells (not equippedSpells) — learning is the gate.
       if (!isSpellKnown(state.knownSpells, requiredSpell)) return state;
 
-      const crystalBal = (balance as Record<string, unknown>).crystalBall as { revealManaCost: number };
+      const crystalBal = bal.crystalBall;
       if (state.mana < crystalBal.revealManaCost) return state;
 
       // Compute the revealed value.
@@ -920,7 +909,7 @@ function applyAction(state: GameState, action: GameAction): GameState {
       if (!state.dadAlive) return state;
       const result = takeLoan(state, action.amount);
       if (!result) return state;
-      const dadBal = balance.dadsHouse as { visitTimeCost: number };
+      const dadBal = bal.dadsHouse;
       const newClock = advanceClock(result.clock, dadBal.visitTimeCost);
       if (isCurfewBreached(newClock, state.currentLocation)) {
         return applyPassout({ ...result, clock: newClock });
@@ -940,7 +929,7 @@ function applyAction(state: GameState, action: GameAction): GameState {
       if (state.phase !== 'playing') return state;
       if (getLocationType(state.currentLocation) !== 'dads_house') return state;
       if (state.dadAlive) return state;
-      const dadBal = balance.dadsHouse as { visitTimeCost: number; graveManaRestore: number; graveChillLoss: number };
+      const dadBal = bal.dadsHouse;
       const newClock = advanceClock(state.clock, dadBal.visitTimeCost);
       if (isCurfewBreached(newClock, state.currentLocation)) {
         return applyPassout({ ...state, clock: newClock });

--- a/src/engine/time.ts
+++ b/src/engine/time.ts
@@ -2,7 +2,26 @@
 // All functions are pure — no side effects, no state mutation.
 
 import type { GameState } from '../state/types';
-import balance from '../data/balance.json';
+import { bal } from '../data/balance-types';
+
+// ─── Calendar Constants ──────────────────────────────────────────────────────
+// Game uses a simplified calendar: 30-day months, 12 months, 360-day years.
+
+export const MINUTES_PER_QUARTER = 15;
+export const MINUTES_PER_DAY = 1440;
+export const DAYS_PER_MONTH = 30;
+export const MONTHS_PER_YEAR = 12;
+export const DAYS_PER_YEAR = DAYS_PER_MONTH * MONTHS_PER_YEAR; // 360
+
+// ─── Timestamp Math ──────────────────────────────────────────────────────────
+
+/** Convert a game timestamp to total minutes for comparison. */
+export function toTotalMinutes(year: number, month: number, day: number, clock: number): number {
+  return year * DAYS_PER_YEAR * MINUTES_PER_DAY
+    + month * DAYS_PER_MONTH * MINUTES_PER_DAY
+    + day * MINUTES_PER_DAY
+    + clock;
+}
 
 // ─── Clock Math ───────────────────────────────────────────────────────────────
 
@@ -10,7 +29,7 @@ import balance from '../data/balance.json';
 // e.g. 605 → 615, 615 → 615, 620 → 630
 export function snapToQuarter(minutes: number): number {
   if (minutes <= 0) return 0;
-  return Math.ceil(minutes / 15) * 15;
+  return Math.ceil(minutes / MINUTES_PER_QUARTER) * MINUTES_PER_QUARTER;
 }
 
 // Advance the clock by a raw cost (snapped to next :15 boundary on arrival).
@@ -34,7 +53,7 @@ export function isCurfewBreached(
   clock: number,
   location: GameState['currentLocation'],
 ): boolean {
-  return clock >= balance.dayCycle.curfewTime && location !== 'tower';
+  return clock >= bal.dayCycle.curfewTime && location !== 'tower';
 }
 
 // ─── Calendar ─────────────────────────────────────────────────────────────────
@@ -48,8 +67,8 @@ export function advanceDay(
   let d = day + 1;
   let m = month;
   let y = year;
-  if (d > 30) { d = 1; m++; }
-  if (m > 12) { m = 1; y++; }
+  if (d > DAYS_PER_MONTH) { d = 1; m++; }
+  if (m > MONTHS_PER_YEAR) { m = 1; y++; }
   return { day: d, month: m, year: y };
 }
 
@@ -59,8 +78,7 @@ export function advanceDay(
 // advance to next day, reset to tower.
 // Call this when isCurfewBreached returns true.
 export function applyPassout(state: GameState): GameState {
-  const penalties = balance.passout as Record<string, { cashPenalty: number; chillRestore: number; manaRestore: number }>;
-  const entry = penalties[state.currentNeighborhood];
+  const entry = bal.passout[state.currentNeighborhood];
   const penalty = entry?.cashPenalty ?? 20;
   const chillRestore = entry?.chillRestore ?? 0.15;
   const manaRestore = entry?.manaRestore ?? 0.25;
@@ -71,7 +89,7 @@ export function applyPassout(state: GameState): GameState {
     cash: Math.max(0, state.cash - penalty),
     chill: Math.round(chillRestore * 100),
     mana: Math.round(manaRestore * state.maxMana),
-    clock: balance.dayCycle.wakeTime,
+    clock: bal.dayCycle.wakeTime,
     currentLocation: 'tower',
     lastPassoutPenalty: penalty,
     scratchSession: null,

--- a/src/state/initial.ts
+++ b/src/state/initial.ts
@@ -1,14 +1,14 @@
 import type { GameState } from './types';
-import balance from '../data/balance.json';
+import { bal } from '../data/balance-types';
 
 export const SAVE_VERSION = 18;
 
 export function createInitialState(): GameState {
   return {
     phase: 'setup',
-    cash: balance.starting.cash,
+    cash: bal.starting.cash,
     // Sprint 2: time & calendar
-    clock: balance.dayCycle.wakeTime,  // 600 = 10:00 AM
+    clock: bal.dayCycle.wakeTime,  // 600 = 10:00 AM
     day: 1,
     month: 1,
     year: 1,
@@ -17,24 +17,24 @@ export function createInitialState(): GameState {
     currentLocation: 'tower',          // new runs start at the tower
     lastPassoutPenalty: null,
     // Sprint 5: chill meter
-    chill: balance.starting.chill,
+    chill: bal.starting.chill,
     // Sprint 6: mana pool
-    mana: balance.starting.mana,
-    maxMana: balance.starting.maxMana,
+    mana: bal.starting.mana,
+    maxMana: bal.starting.maxMana,
     // Sprint 7: inventory
     inventory: [null, null, null, null, null],
     // Sprint 8: player stats
-    intelligence: balance.starting.intelligence,
-    bookbinding: balance.starting.bookbinding,
-    wizardFame: balance.starting.wizardFame,
+    intelligence: bal.starting.intelligence,
+    bookbinding: bal.starting.bookbinding,
+    wizardFame: bal.starting.wizardFame,
     peakWizardFame: 0,  // Sprint 26: starts at 0, updated via dispatch post-processing
-    relaxationRate: balance.starting.relaxationRate,
-    restingRelaxation: balance.starting.restingRelaxation,
+    relaxationRate: bal.starting.relaxationRate,
+    restingRelaxation: bal.starting.restingRelaxation,
     // Sprint 17: hidden addiction stats
     addictionNeed: 0,
     addictionSatisfaction: 0,
     // Sprint 18 stub: age health score
-    ageHealthScore: balance.starting.ageHealthScore,
+    ageHealthScore: bal.starting.ageHealthScore,
     // Sprint 19: crystal ball reveal (transient)
     crystalBallReveal: null,
     // Sprint 13: furniture (start with one basic bed)

--- a/src/systems/addiction.ts
+++ b/src/systems/addiction.ts
@@ -2,18 +2,18 @@
 // Hidden stat tracking scratcher dependency.
 // All functions are pure — no side effects, no held state.
 
-import balance from '../data/balance.json';
+import { bal } from '../data/balance-types';
 
 // Grow need when the player buys tickets (frequency-driven).
 // Called once per BUY_TICKETS action with the total ticket count purchased.
 export function growNeed(need: number, numTickets: number): number {
-  return need + numTickets * balance.addiction.needGrowthRate;
+  return need + numTickets * bal.addiction.needGrowthRate;
 }
 
 // Gain satisfaction from completing a scratch session.
 // Called at FINISH_SESSION with the total number of tickets scratched in the session.
 export function gainSatisfaction(satisfaction: number, numTickets: number): number {
-  return satisfaction + numTickets * balance.addiction.satisfactionPerTicket;
+  return satisfaction + numTickets * bal.addiction.satisfactionPerTicket;
 }
 
 // Compute effective restingRelaxation given current addiction need.
@@ -21,6 +21,6 @@ export function gainSatisfaction(satisfaction: number, numTickets: number): numb
 // from the starting base. Floors at 0.
 export function computeRestingRelaxation(need: number): number {
   const level = Math.floor(need);
-  const penalty = level * balance.addiction.restingRelaxationPenaltyPerLevel;
-  return Math.max(0, balance.starting.restingRelaxation - penalty);
+  const penalty = level * bal.addiction.restingRelaxationPenaltyPerLevel;
+  return Math.max(0, bal.starting.restingRelaxation - penalty);
 }

--- a/src/systems/affinity.ts
+++ b/src/systems/affinity.ts
@@ -4,16 +4,12 @@
 
 import type { GodId, PrayerBuff } from '../state/types';
 import { getOpposedGod, getGod } from '../data/gods';
-import balance from '../data/balance.json';
+import { bal } from '../data/balance-types';
+import { toTotalMinutes, MINUTES_PER_DAY, DAYS_PER_MONTH, MONTHS_PER_YEAR } from '../engine/time';
 
-const aff = balance.affinity;
+const aff = bal.affinity;
 
 // ─── Timestamp Math ──────────────────────────────────────────────────────────
-
-// Convert game timestamp to total minutes for comparison.
-function toTotalMinutes(year: number, month: number, day: number, clock: number): number {
-  return year * 360 * 1440 + month * 30 * 1440 + day * 1440 + clock;
-}
 
 // Add minutes to a game timestamp, handling day/month/year rollover.
 export function addMinutesToTimestamp(
@@ -23,11 +19,11 @@ export function addMinutesToTimestamp(
   let d = day;
   let m = month;
   let y = year;
-  while (c >= 1440) {
-    c -= 1440;
+  while (c >= MINUTES_PER_DAY) {
+    c -= MINUTES_PER_DAY;
     d++;
-    if (d > 30) { d = 1; m++; }
-    if (m > 12) { m = 1; y++; }
+    if (d > DAYS_PER_MONTH) { d = 1; m++; }
+    if (m > MONTHS_PER_YEAR) { m = 1; y++; }
   }
   return { clock: c, day: d, month: m, year: y };
 }
@@ -99,8 +95,7 @@ export function applyDonation(
   const strongMultiplier = isStrongMonth ? aff.strongMonthMultiplier : 1;
 
   // Sprint 24: neighborhood god strength boosts gain (but not loss).
-  const nbStrength = (balance as Record<string, unknown>).neighborhoodGodStrength as { affinityGainMultiplier: number };
-  const neighborhoodMultiplier = dominantGods.includes(godId) ? nbStrength.affinityGainMultiplier : 1;
+  const neighborhoodMultiplier = dominantGods.includes(godId) ? bal.neighborhoodGodStrength.affinityGainMultiplier : 1;
 
   const gain = baseChange * (hasTargetBuff ? aff.prayerBuffMultiplier : 1) * strongMultiplier * neighborhoodMultiplier;
   const loss = hasOpposedBuff ? baseChange * aff.prayerDebuffMultiplier : baseChange;
@@ -125,9 +120,7 @@ export function applyMonumentDonation(
   clock: number, day: number, month: number, year: number,
   dominantGods: GodId[] = [],
 ): Record<GodId, number> {
-  const monBal = (balance as Record<string, unknown>).monumentDonation as
-    Record<string, { affinityGain: number; opposedLoss: number }>;
-  const { affinityGain: baseGain, opposedLoss: baseLoss } = monBal[size];
+  const { affinityGain: baseGain, opposedLoss: baseLoss } = bal.monumentDonation[size];
 
   const opposedGod = getOpposedGod(godId);
   const hasTargetBuff = hasPrayerBuff(buffs, godId, clock, day, month, year);
@@ -137,8 +130,7 @@ export function applyMonumentDonation(
   const strongMultiplier = isStrongMonth ? aff.strongMonthMultiplier : 1;
 
   // Sprint 24: neighborhood god strength boosts gain (but not loss).
-  const nbStrength = (balance as Record<string, unknown>).neighborhoodGodStrength as { affinityGainMultiplier: number };
-  const neighborhoodMultiplier = dominantGods.includes(godId) ? nbStrength.affinityGainMultiplier : 1;
+  const neighborhoodMultiplier = dominantGods.includes(godId) ? bal.neighborhoodGodStrength.affinityGainMultiplier : 1;
 
   const gain = baseGain * (hasTargetBuff ? aff.prayerBuffMultiplier : 1) * strongMultiplier * neighborhoodMultiplier;
   const loss = hasOpposedBuff ? baseLoss * aff.prayerDebuffMultiplier : baseLoss;

--- a/src/systems/events.ts
+++ b/src/systems/events.ts
@@ -13,9 +13,7 @@ import { removeFurniture } from './furniture';
 import { growNeed } from './addiction';
 import { getGod } from '../data/gods';
 import { advanceClock } from '../engine/time';
-import balance from '../data/balance.json';
-
-const evtBal = (balance as Record<string, unknown>).randomEvents as Record<string, Record<string, number>>;
+import { bal } from '../data/balance-types';
 
 // ─── Trigger Checking ────────────────────────────────────────────────────────
 
@@ -65,7 +63,7 @@ export function checkForEvent(
     // Dad Dies: require dadAlive and minimum year.
     if (def.id === 'dad_dies') {
       if (!state.dadAlive) return false;
-      const minYear = evtBal.dad_dies?.minYear ?? 3;
+      const minYear = bal.randomEvents.dad_dies?.minYear ?? 3;
       if (state.year < minYear) return false;
     }
 
@@ -137,7 +135,7 @@ export function resolveEvent(state: GameState, choiceIndex: number): GameState {
 // ─── Per-Event Resolution ────────────────────────────────────────────────────
 
 function resolveBirthday(state: GameState, choice: number): GameState {
-  const bal = evtBal.birthday;
+  const eb = bal.randomEvents.birthday;
   // Show which god is strong this month.
   const strongGods = ['mesin', 'gul', 'klossa', 'skarhol', 'marena', 'azorius', 'ara', 'finhorn', 'beroan', 'sofiel']
     .filter(id => getGod(id as GodId).strongMonths.includes(state.month));
@@ -148,24 +146,24 @@ function resolveBirthday(state: GameState, choice: number): GameState {
 
   switch (choice) {
     case 0: // Celebrate alone
-      nextState = { ...nextState, chill: applyChillGain(nextState.chill, bal.celebrateChillGain) };
+      nextState = { ...nextState, chill: applyChillGain(nextState.chill, eb.celebrateChillGain) };
       outcomeText = `You eat cake alone. Chill restored. ${godName} is strong this month.`;
       break;
     case 1: // Buy something
-      if (nextState.cash >= bal.buySomethingCost) {
+      if (nextState.cash >= eb.buySomethingCost) {
         nextState = {
           ...nextState,
-          cash: nextState.cash - bal.buySomethingCost,
-          chill: applyChillGain(nextState.chill, bal.buySomethingChillGain),
+          cash: nextState.cash - eb.buySomethingCost,
+          chill: applyChillGain(nextState.chill, eb.buySomethingChillGain),
         };
-        outcomeText = `You treated yourself. -$${bal.buySomethingCost}. ${godName} is strong this month.`;
+        outcomeText = `You treated yourself. -$${eb.buySomethingCost}. ${godName} is strong this month.`;
       } else {
-        nextState = { ...nextState, chill: applyChillGain(nextState.chill, bal.celebrateChillGain) };
+        nextState = { ...nextState, chill: applyChillGain(nextState.chill, eb.celebrateChillGain) };
         outcomeText = `Can't afford it. You celebrate alone instead. ${godName} is strong this month.`;
       }
       break;
     case 2: // Contemplate mortality
-      nextState = { ...nextState, mana: applyManaRestore(nextState.mana, bal.contemplateManaGain, nextState.maxMana) };
+      nextState = { ...nextState, mana: applyManaRestore(nextState.mana, eb.contemplateManaGain, nextState.maxMana) };
       outcomeText = `You stare into the void. Mana restored. ${godName} is strong this month.`;
       break;
     default:
@@ -176,7 +174,7 @@ function resolveBirthday(state: GameState, choice: number): GameState {
 }
 
 function resolveDadDies(state: GameState, choice: number): GameState {
-  const bal = evtBal.dad_dies;
+  const eb = bal.randomEvents.dad_dies;
   let outcomeText: string;
   let nextState = { ...state, dadAlive: false };
 
@@ -184,17 +182,17 @@ function resolveDadDies(state: GameState, choice: number): GameState {
     case 0: // Grieve
       nextState = {
         ...nextState,
-        chill: Math.max(0, nextState.chill - bal.grieveChillLoss),
-        mana: applyManaRestore(nextState.mana, bal.grieveManaGain, nextState.maxMana),
+        chill: Math.max(0, nextState.chill - eb.grieveChillLoss),
+        mana: applyManaRestore(nextState.mana, eb.grieveManaGain, nextState.maxMana),
       };
       outcomeText = 'You let yourself feel it. The magic stirs.';
       break;
     case 1: // Check the will
-      nextState = { ...nextState, cash: nextState.cash + bal.inheritanceCash };
-      outcomeText = `He left you $${bal.inheritanceCash}. Typical.`;
+      nextState = { ...nextState, cash: nextState.cash + eb.inheritanceCash };
+      outcomeText = `He left you $${eb.inheritanceCash}. Typical.`;
       break;
     case 2: // Already dead to me
-      nextState = { ...nextState, chill: applyChillGain(nextState.chill, bal.dismissChillGain) };
+      nextState = { ...nextState, chill: applyChillGain(nextState.chill, eb.dismissChillGain) };
       outcomeText = "You shrug it off. You've been doing that your whole life.";
       break;
     default:
@@ -205,7 +203,7 @@ function resolveDadDies(state: GameState, choice: number): GameState {
 }
 
 function resolveBongBreaks(state: GameState, choice: number): GameState {
-  const bal = evtBal.bong_breaks;
+  const eb = bal.randomEvents.bong_breaks;
   let outcomeText: string;
   let nextState = state;
 
@@ -216,7 +214,7 @@ function resolveBongBreaks(state: GameState, choice: number): GameState {
     case 0: // Mourn it
       nextState = {
         ...nextState,
-        chill: Math.max(0, nextState.chill - bal.mournChillLoss),
+        chill: Math.max(0, nextState.chill - eb.mournChillLoss),
         furniture: bongIdx >= 0 ? removeFurniture(nextState.furniture, bongIdx) : nextState.furniture,
       };
       outcomeText = 'Gone but not forgotten. Your chill drops.';
@@ -224,13 +222,13 @@ function resolveBongBreaks(state: GameState, choice: number): GameState {
     case 1: { // Try to fix it
       const [roll, nextSeed] = rng(nextState.rngSeed);
       nextState = { ...nextState, rngSeed: nextSeed };
-      if (roll < bal.fixChance) {
-        nextState = { ...nextState, chill: applyChillGain(nextState.chill, bal.fixSuccessChillGain) };
+      if (roll < eb.fixChance) {
+        nextState = { ...nextState, chill: applyChillGain(nextState.chill, eb.fixSuccessChillGain) };
         outcomeText = "You managed to fix it! It's not pretty, but it works.";
       } else {
         nextState = {
           ...nextState,
-          chill: Math.max(0, nextState.chill - bal.fixFailChillLoss),
+          chill: Math.max(0, nextState.chill - eb.fixFailChillLoss),
           furniture: bongIdx >= 0 ? removeFurniture(nextState.furniture, bongIdx) : nextState.furniture,
         };
         outcomeText = 'The repair failed. It shatters completely.';
@@ -240,7 +238,7 @@ function resolveBongBreaks(state: GameState, choice: number): GameState {
     case 2: // Throw it out
       nextState = {
         ...nextState,
-        chill: applyChillGain(nextState.chill, bal.throwOutChillGain),
+        chill: applyChillGain(nextState.chill, eb.throwOutChillGain),
         furniture: bongIdx >= 0 ? removeFurniture(nextState.furniture, bongIdx) : nextState.furniture,
       };
       outcomeText = 'You toss it. Somehow that feels right.';
@@ -253,25 +251,25 @@ function resolveBongBreaks(state: GameState, choice: number): GameState {
 }
 
 function resolveSuspiciousClerk(state: GameState, choice: number): GameState {
-  const bal = evtBal.suspicious_clerk;
+  const eb = bal.randomEvents.suspicious_clerk;
   let outcomeText: string;
   let nextState = state;
 
   switch (choice) {
     case 0: // Act natural
-      nextState = { ...nextState, chill: applyChillGain(nextState.chill, bal.actNaturalChillGain) };
+      nextState = { ...nextState, chill: applyChillGain(nextState.chill, eb.actNaturalChillGain) };
       outcomeText = 'You play it cool. The clerk loses interest.';
       break;
     case 1: // Leave
-      nextState = { ...nextState, chill: Math.max(0, nextState.chill - bal.leaveChillLoss) };
+      nextState = { ...nextState, chill: Math.max(0, nextState.chill - eb.leaveChillLoss) };
       outcomeText = 'You leave. The paranoia lingers.';
       break;
     case 2: // Smooth talk
-      if (state.wizardFame >= bal.smoothTalkFameReq) {
-        nextState = { ...nextState, chill: applyChillGain(nextState.chill, bal.smoothTalkChillGain) };
+      if (state.wizardFame >= eb.smoothTalkFameReq) {
+        nextState = { ...nextState, chill: applyChillGain(nextState.chill, eb.smoothTalkChillGain) };
         outcomeText = 'You charm the clerk. They even give you a discount smile.';
       } else {
-        nextState = { ...nextState, chill: Math.max(0, nextState.chill - bal.leaveChillLoss) };
+        nextState = { ...nextState, chill: Math.max(0, nextState.chill - eb.leaveChillLoss) };
         outcomeText = "The clerk isn't buying it. Awkward.";
       }
       break;
@@ -283,18 +281,18 @@ function resolveSuspiciousClerk(state: GameState, choice: number): GameState {
 }
 
 function resolveFellowScratcher(state: GameState, choice: number): GameState {
-  const bal = evtBal.fellow_scratcher;
+  const eb = bal.randomEvents.fellow_scratcher;
   let outcomeText: string;
   let nextState = state;
 
   switch (choice) {
     case 0: // Chat
-      nextState = { ...nextState, chill: applyChillGain(nextState.chill, bal.chatChillGain) };
+      nextState = { ...nextState, chill: applyChillGain(nextState.chill, eb.chatChillGain) };
       outcomeText = 'You swap stories. Feels good to not be the only one.';
       break;
     case 1: // Ignore
-      nextState = { ...nextState, cash: nextState.cash + bal.ignoreCashFind };
-      outcomeText = `You look away and find $${bal.ignoreCashFind} on the ground. Nice.`;
+      nextState = { ...nextState, cash: nextState.cash + eb.ignoreCashFind };
+      outcomeText = `You look away and find $${eb.ignoreCashFind} on the ground. Nice.`;
       break;
     case 2: { // Share tips
       // Pick a random god to boost affinity.
@@ -305,7 +303,7 @@ function resolveFellowScratcher(state: GameState, choice: number): GameState {
       const godId = gods[godIdx];
       const godName = getGod(godId).name;
       const newAffinity = { ...nextState.affinity };
-      newAffinity[godId] = newAffinity[godId] + bal.shareTipAffinityGain;
+      newAffinity[godId] = newAffinity[godId] + eb.shareTipAffinityGain;
       nextState = { ...nextState, affinity: newAffinity };
       outcomeText = `You share a tip about ${godName}'s symbols. Good karma.`;
       break;
@@ -318,7 +316,7 @@ function resolveFellowScratcher(state: GameState, choice: number): GameState {
 }
 
 function resolveTempleJudgment(state: GameState, choice: number): GameState {
-  const bal = evtBal.temple_judgment;
+  const eb = bal.randomEvents.temple_judgment;
   let outcomeText: string;
   let nextState = state;
 
@@ -330,24 +328,26 @@ function resolveTempleJudgment(state: GameState, choice: number): GameState {
   const godName = getGod(godId).name;
 
   switch (choice) {
-    case 0: // Confess
+    case 0: { // Confess
       const newAff = { ...nextState.affinity };
-      newAff[godId] = newAff[godId] + bal.confessAffinityGain;
+      newAff[godId] = newAff[godId] + eb.confessAffinityGain;
       nextState = { ...nextState, affinity: newAff };
       outcomeText = `You confess. ${godName} approves.`;
       break;
-    case 1: // Deny
+    }
+    case 1: { // Deny
       const newAff2 = { ...nextState.affinity };
-      newAff2[godId] = newAff2[godId] - bal.denyAffinityLoss;
+      newAff2[godId] = newAff2[godId] - eb.denyAffinityLoss;
       nextState = {
         ...nextState,
-        chill: Math.max(0, nextState.chill - bal.denyChillLoss),
+        chill: Math.max(0, nextState.chill - eb.denyChillLoss),
         affinity: newAff2,
       };
       outcomeText = `You deny it. ${godName} is not amused.`;
       break;
+    }
     case 2: // Laugh
-      nextState = { ...nextState, wizardFame: nextState.wizardFame + bal.laughFameGain };
+      nextState = { ...nextState, wizardFame: nextState.wizardFame + eb.laughFameGain };
       outcomeText = 'You laugh. A nearby pilgrim is impressed by your confidence.';
       break;
     default:
@@ -358,13 +358,13 @@ function resolveTempleJudgment(state: GameState, choice: number): GameState {
 }
 
 function resolveCampusEncounter(state: GameState, choice: number): GameState {
-  const bal = evtBal.campus_encounter;
+  const eb = bal.randomEvents.campus_encounter;
   let outcomeText: string;
   let nextState = state;
 
   switch (choice) {
     case 0: // Brag
-      nextState = { ...nextState, wizardFame: nextState.wizardFame + bal.bragFameGain };
+      nextState = { ...nextState, wizardFame: nextState.wizardFame + eb.bragFameGain };
       outcomeText = "You embellish wildly. They're impressed.";
       break;
     case 1: // Hide
@@ -373,8 +373,8 @@ function resolveCampusEncounter(state: GameState, choice: number): GameState {
     case 2: // Catch up
       nextState = {
         ...nextState,
-        chill: applyChillGain(nextState.chill, bal.chatChillGain),
-        wizardFame: nextState.wizardFame + bal.chatFameGain,
+        chill: applyChillGain(nextState.chill, eb.chatChillGain),
+        wizardFame: nextState.wizardFame + eb.chatFameGain,
       };
       outcomeText = 'You catch up. It feels almost normal.';
       break;
@@ -386,7 +386,7 @@ function resolveCampusEncounter(state: GameState, choice: number): GameState {
 }
 
 function resolveLoanShark(state: GameState, choice: number): GameState {
-  const bal = evtBal.loan_shark;
+  const eb = bal.randomEvents.loan_shark;
   let outcomeText: string;
   let nextState = state;
 
@@ -394,18 +394,18 @@ function resolveLoanShark(state: GameState, choice: number): GameState {
     case 0: // Take the money
       nextState = {
         ...nextState,
-        cash: nextState.cash + bal.loanAmount,
-        loanSharkDebt: bal.loanAmount,
-        loanSharkInterestRate: bal.interestRate,
+        cash: nextState.cash + eb.loanAmount,
+        loanSharkDebt: eb.loanAmount,
+        loanSharkInterestRate: eb.interestRate,
       };
-      outcomeText = `You take $${bal.loanAmount}. The coat smiles. You owe them.`;
+      outcomeText = `You take $${eb.loanAmount}. The coat smiles. You owe them.`;
       break;
     case 1: // Decline
-      nextState = { ...nextState, chill: applyChillGain(nextState.chill, bal.declineChillGain) };
+      nextState = { ...nextState, chill: applyChillGain(nextState.chill, eb.declineChillGain) };
       outcomeText = "You decline. They shrug and walk away.";
       break;
     case 2: // Tell them off
-      nextState = { ...nextState, chill: Math.max(0, nextState.chill - bal.intimidateChillLoss) };
+      nextState = { ...nextState, chill: Math.max(0, nextState.chill - eb.intimidateChillLoss) };
       outcomeText = 'They lean in close. You regret that immediately.';
       break;
     default:
@@ -416,7 +416,7 @@ function resolveLoanShark(state: GameState, choice: number): GameState {
 }
 
 function resolveStormWarning(state: GameState, choice: number): GameState {
-  const bal = evtBal.storm_warning;
+  const eb = bal.randomEvents.storm_warning;
   let outcomeText: string;
   let nextState = state;
 
@@ -424,16 +424,16 @@ function resolveStormWarning(state: GameState, choice: number): GameState {
     case 0: // Push through
       nextState = {
         ...nextState,
-        clock: advanceClock(nextState.clock, bal.pushThroughExtraMinutes),
-        chill: Math.max(0, nextState.chill - bal.pushThroughChillLoss),
+        clock: advanceClock(nextState.clock, eb.pushThroughExtraMinutes),
+        chill: Math.max(0, nextState.chill - eb.pushThroughChillLoss),
       };
       outcomeText = 'You push through the storm. Soaked and rattled.';
       break;
     case 1: // Find shelter
       nextState = {
         ...nextState,
-        clock: advanceClock(nextState.clock, bal.shelterExtraMinutes),
-        chill: applyChillGain(nextState.chill, bal.shelterChillGain),
+        clock: advanceClock(nextState.clock, eb.shelterExtraMinutes),
+        chill: applyChillGain(nextState.chill, eb.shelterChillGain),
       };
       outcomeText = 'You wait it out under an awning. Not bad, actually.';
       break;
@@ -449,26 +449,26 @@ function resolveStormWarning(state: GameState, choice: number): GameState {
 }
 
 function resolveWinningTicket(state: GameState, choice: number): GameState {
-  const bal = evtBal.winning_ticket;
+  const eb = bal.randomEvents.winning_ticket;
   let outcomeText: string;
   let nextState = state;
 
   switch (choice) {
     case 0: // Cheer
-      nextState = { ...nextState, chill: applyChillGain(nextState.chill, bal.cheerChillGain) };
+      nextState = { ...nextState, chill: applyChillGain(nextState.chill, eb.cheerChillGain) };
       outcomeText = "You cheer. They buy you a coffee. Life's alright.";
       break;
     case 1: // Seethe
       nextState = {
         ...nextState,
-        chill: Math.max(0, nextState.chill - bal.envyChillLoss),
+        chill: Math.max(0, nextState.chill - eb.envyChillLoss),
         addictionNeed: growNeed(nextState.addictionNeed, 1),
       };
       outcomeText = 'The jealousy burns. You need to scratch.';
       break;
     case 2: // Ask for cut
-      nextState = { ...nextState, cash: nextState.cash + bal.hustleCashGain };
-      outcomeText = `They laugh but toss you $${bal.hustleCashGain}. Not bad.`;
+      nextState = { ...nextState, cash: nextState.cash + eb.hustleCashGain };
+      outcomeText = `They laugh but toss you $${eb.hustleCashGain}. Not bad.`;
       break;
     default:
       outcomeText = 'The winner walks away.';
@@ -478,7 +478,7 @@ function resolveWinningTicket(state: GameState, choice: number): GameState {
 }
 
 function resolveWizardFameMoment(state: GameState, choice: number): GameState {
-  const bal = evtBal.wizard_fame_moment;
+  const eb = bal.randomEvents.wizard_fame_moment;
   let outcomeText: string;
   let nextState = state;
 
@@ -486,22 +486,22 @@ function resolveWizardFameMoment(state: GameState, choice: number): GameState {
     case 0: // Embrace
       nextState = {
         ...nextState,
-        wizardFame: nextState.wizardFame + bal.embraceFameGain,
-        chill: applyChillGain(nextState.chill, bal.embraceChillGain),
+        wizardFame: nextState.wizardFame + eb.embraceFameGain,
+        chill: applyChillGain(nextState.chill, eb.embraceChillGain),
       };
       outcomeText = 'You wave. They wave back. Celebrity vibes.';
       break;
     case 1: // Deny
-      nextState = { ...nextState, wizardFame: Math.max(0, nextState.wizardFame - bal.denyFameLoss) };
+      nextState = { ...nextState, wizardFame: Math.max(0, nextState.wizardFame - eb.denyFameLoss) };
       outcomeText = '"Wrong wizard." They look confused.';
       break;
     case 2: // Exploit
       nextState = {
         ...nextState,
-        cash: nextState.cash + bal.exploitCashGain,
-        wizardFame: Math.max(0, nextState.wizardFame - bal.exploitFameLoss),
+        cash: nextState.cash + eb.exploitCashGain,
+        wizardFame: Math.max(0, nextState.wizardFame - eb.exploitFameLoss),
       };
-      outcomeText = `You sign autographs for $${bal.exploitCashGain}. Fame fades.`;
+      outcomeText = `You sign autographs for $${eb.exploitCashGain}. Fame fades.`;
       break;
     default:
       outcomeText = 'They walk away.';
@@ -511,7 +511,7 @@ function resolveWizardFameMoment(state: GameState, choice: number): GameState {
 }
 
 function resolveBadBatch(state: GameState, choice: number): GameState {
-  const bal = evtBal.bad_batch;
+  const bb = bal.randomEvents.bad_batch;
   let outcomeText: string;
   let nextState = state;
 
@@ -519,15 +519,15 @@ function resolveBadBatch(state: GameState, choice: number): GameState {
     case 0: // Scratch anyway
       // The odds modifier would need to be applied to the next scratch session.
       // For now, apply chill loss. The modifier is stored transiently via the event system.
-      nextState = { ...nextState, chill: Math.max(0, nextState.chill - bal.scratchAnywayChillLoss) };
+      nextState = { ...nextState, chill: Math.max(0, nextState.chill - bb.scratchAnywayChillLoss) };
       outcomeText = 'You scratch them. They feel wrong in your hands.';
       break;
     case 1: // Swap tickets
-      nextState = { ...nextState, clock: advanceClock(nextState.clock, bal.swapTicketsTimeCost) };
+      nextState = { ...nextState, clock: advanceClock(nextState.clock, bb.swapTicketsTimeCost) };
       outcomeText = 'The clerk swaps them out. Took a while.';
       break;
     case 2: // Leave
-      nextState = { ...nextState, chill: Math.max(0, nextState.chill - bal.leaveChillLoss) };
+      nextState = { ...nextState, chill: Math.max(0, nextState.chill - bb.leaveChillLoss) };
       outcomeText = 'You leave empty-handed. The paranoia lingers.';
       break;
     default:

--- a/src/systems/loan.ts
+++ b/src/systems/loan.ts
@@ -1,9 +1,9 @@
 // Loan system — pure functions for Dad's House loans (Sprint 22).
 
 import type { GameState, LoanState } from '../state/types';
-import balance from '../data/balance.json';
+import { bal } from '../data/balance-types';
 
-const cfg = balance.dadsHouse;
+const cfg = bal.dadsHouse;
 
 export function calculateLoanCap(wizardFame: number): number {
   return Math.min(cfg.maxLoanCap, cfg.baseLoanCap + wizardFame * cfg.fameCapBonus);

--- a/src/systems/projects.ts
+++ b/src/systems/projects.ts
@@ -6,9 +6,9 @@ import type { GameState, InventoryItem, ProjectState } from '../state/types';
 import { getProjectDef } from '../data/projects';
 import { addItem, freeSlots } from './inventory';
 import { applyChillLoss } from './chill';
-import balance from '../data/balance.json';
+import { bal } from '../data/balance-types';
 
-const proj = (balance as any).projects;
+const proj = bal.projects;
 
 // ─── Queries ─────────────────────────────────────────────────────────────────
 

--- a/src/systems/rent.ts
+++ b/src/systems/rent.ts
@@ -3,7 +3,7 @@
 // Pure functions only; no side effects.
 
 import type { GameState } from '../state/types';
-import balance from '../data/balance.json';
+import { bal } from '../data/balance-types';
 
 // Compute days survived from the game calendar.
 // Day 1, Month 1, Year 1 = 0 days survived.
@@ -18,8 +18,8 @@ export function calcDaysSurvived(day: number, month: number, year: number): numb
 //   - day === dueDay, cash >= amount  →  deduct rent, continue
 //   - day === dueDay, cash < amount   →  game over
 export function checkRent(state: GameState): GameState {
-  if (state.day !== balance.rent.dueDay) return state;
-  const rentAmount = balance.rent.amount;
+  if (state.day !== bal.rent.dueDay) return state;
+  const rentAmount = bal.rent.amount;
   if (state.cash < rentAmount) {
     return { ...state, phase: 'game_over' };
   }

--- a/src/systems/scratch.ts
+++ b/src/systems/scratch.ts
@@ -8,7 +8,7 @@ import { rng, weightedRandom, randInt } from '../util/rng';
 import { calcScratchTimeCost } from '../util/format';
 import { applyChillLoss, applyChillGain } from './chill';
 import { calcAffinityPayoutMultiplier } from './affinity';
-import balance from '../data/balance.json';
+import { bal } from '../data/balance-types';
 
 // ─── Ticket Generation ────────────────────────────────────────────────────────
 
@@ -51,10 +51,10 @@ function generateTicket(
   let s = seed;
 
   // ── Determine win or loss ──
-  let r: number;
-  [r, s] = rng(s);
+  const [winRoll, s2] = rng(s);
+  s = s2;
   const effectiveWinChance = Math.min(1, type.winChance + winChanceBonus);
-  const isWin = r < effectiveWinChance;
+  const isWin = winRoll < effectiveWinChance;
 
   if (isWin) {
     // ── Pick match count ──
@@ -65,8 +65,7 @@ function generateTicket(
     // ── Pick winning symbol (Sprint 24: weighted by neighborhood god strength) ──
     let symIdx: number;
     if (dominantGods.length > 0) {
-      const nbStr = (balance as Record<string, unknown>).neighborhoodGodStrength as { symbolWeightBonus: number };
-      const weights = SYMBOLS.map(sym => dominantGods.includes(sym.god) ? 1 + nbStr.symbolWeightBonus : 1);
+      const weights = SYMBOLS.map(sym => dominantGods.includes(sym.god) ? 1 + bal.neighborhoodGodStrength.symbolWeightBonus : 1);
       [symIdx, s] = weightedRandom(weights, s);
     } else {
       [symIdx, s] = randInt(SYMBOLS.length, s);
@@ -161,7 +160,7 @@ function fillLossCells(
 
   // Sprint 24: pre-compute weight bonus for dominant gods.
   const nbStr = dominantGods.length > 0
-    ? (balance as Record<string, unknown>).neighborhoodGodStrength as { symbolWeightBonus: number }
+    ? bal.neighborhoodGodStrength
     : null;
 
   // Track counts to avoid accidental 3+ of any non-excluded symbol.
@@ -298,9 +297,9 @@ export function scratchCell(
 
     // Sprint 5: chill reacts to scratch outcomes.
     if (newTicket.isWin) {
-      newChill = applyChillGain(newChill, balance.chill.gainPerScratchWin);
+      newChill = applyChillGain(newChill, bal.chill.gainPerScratchWin);
     } else {
-      newChill = applyChillLoss(newChill, balance.chill.lossPerScratchLoss);
+      newChill = applyChillLoss(newChill, bal.chill.lossPerScratchLoss);
     }
   }
 

--- a/src/systems/spellbook.ts
+++ b/src/systems/spellbook.ts
@@ -4,16 +4,11 @@
 import { snapToQuarter } from '../engine/time';
 import { getAllSpells, type SpellDef } from '../data/spells';
 import { randInt } from '../util/rng';
-import balance from '../data/balance.json';
+import { bal } from '../data/balance-types';
 
-const universityBal = (balance as Record<string, unknown>).university as {
-  intelligenceSpeedFactor: number;
-};
+const universityBal = bal.university;
 
-const spellbookBal = (balance as Record<string, unknown>).spellbook as {
-  addTimeMultiplier: number;
-  removeTimeMultiplier: number;
-};
+const spellbookBal = bal.spellbook;
 
 // ─── Daily Class Selection ───────────────────────────────────────────────────
 
@@ -33,13 +28,13 @@ export function getDailyClasses(
   let seed = (year * 1000000 + month * 10000 + day * 100 + 7) | 0;
 
   const indices: number[] = [];
-  const available = allSpells.map((_, i) => i);
+  let available = allSpells.map((_, i) => i);
 
   for (let i = 0; i < numClasses; i++) {
     const [roll, nextSeed] = randInt(available.length, seed);
     seed = nextSeed;
     indices.push(available[roll]);
-    available.splice(roll, 1);
+    available = available.filter((_, idx) => idx !== roll);
   }
 
   return indices.map(i => allSpells[i]);
@@ -101,9 +96,7 @@ export function calcRemoveFromBookTime(castingTime: number): number {
 
 // ─── Misfire (Sprint 15) ─────────────────────────────────────────────────────
 
-const spellsBal = (balance as Record<string, unknown>).spells as {
-  chillMisfireScaling: number;
-};
+const spellsBal = bal.spells;
 
 // Returns the effective misfire chance for a spell, factoring in Chill level.
 // Formula: baseMisfireChance + max(0, 50 − chill) × chillMisfireScaling

--- a/src/systems/travel.ts
+++ b/src/systems/travel.ts
@@ -3,7 +3,7 @@
 // Sprint 4: cross-neighborhood travel (15 min raw); currentNeighborhood updated on travel.
 
 import type { GameState, LocationId } from '../state/types';
-import balance from '../data/balance.json';
+import { bal } from '../data/balance-types';
 import { advanceClock, isCurfewBreached, applyPassout, snapToQuarter } from '../engine/time';
 import { getLocationNeighborhood } from '../data/locations';
 
@@ -15,9 +15,9 @@ export function getTravelCostRaw(from: LocationId, to: LocationId): number {
   const fromNeighborhood = getLocationNeighborhood(from);
   const toNeighborhood   = getLocationNeighborhood(to);
   if (fromNeighborhood === toNeighborhood) {
-    return balance.travel.sameNeighborhoodMinutes;
+    return bal.travel.sameNeighborhoodMinutes;
   }
-  return balance.travel.crossNeighborhoodMinutes;
+  return bal.travel.crossNeighborhoodMinutes;
 }
 
 // How much the clock visually advances for this trip (snapped to :15).

--- a/src/ui/components.ts
+++ b/src/ui/components.ts
@@ -3,7 +3,7 @@
 
 import type { GameState, InventoryItem, GodId } from '../state/types';
 import { progressBar } from '../util/format';
-import balance from '../data/balance.json';
+import { bal } from '../data/balance-types';
 import { getSpellDef } from '../data/spells';
 import { ALL_GOD_IDS, getGod } from '../data/gods';
 
@@ -199,7 +199,7 @@ export function makeStatsPanel(state: GameState): HTMLElement {
 
   panel.appendChild(makeHeader('STATS'));
 
-  const dm = balance.stats.displayMax;
+  const dm = bal.stats.displayMax;
   const stats: Array<{ label: string; value: number; max: number }> = [
     { label: 'INT ', value: state.intelligence,      max: dm.intelligence },
     { label: 'BIND', value: state.bookbinding,       max: dm.bookbinding },

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -44,7 +44,5 @@ export function renderHUD(state: GameState, el: HTMLElement): void {
   row2.appendChild(chillEl);
   row2.appendChild(manaEl);
 
-  el.innerHTML = '';
-  el.appendChild(row1);
-  el.appendChild(row2);
+  el.replaceChildren(row1, row2);
 }

--- a/src/ui/renderer.ts
+++ b/src/ui/renderer.ts
@@ -44,7 +44,7 @@ let _screenEl: HTMLElement | null = null;
 
 function ensureLayout(container: HTMLElement): { hud: HTMLElement; screen: HTMLElement } {
   if (!_hudEl || !container.contains(_hudEl)) {
-    container.innerHTML = '';
+    container.replaceChildren();
     container.style.flexDirection = 'column';
     container.style.alignItems = 'center';
 
@@ -58,7 +58,9 @@ function ensureLayout(container: HTMLElement): { hud: HTMLElement; screen: HTMLE
     container.appendChild(_screenEl);
     currentScreen = 'none';  // force full re-render after layout reset
   }
-  return { hud: _hudEl!, screen: _screenEl! };
+  // Both elements are guaranteed non-null here: either they existed and passed
+  // the contains() check, or they were just created above.
+  return { hud: _hudEl as HTMLElement, screen: _screenEl as HTMLElement };
 }
 
 // ─── Screen Routing ───────────────────────────────────────────────────────────

--- a/src/ui/screens/bar.ts
+++ b/src/ui/screens/bar.ts
@@ -33,7 +33,7 @@ const snackQtys: Record<string, number> = {};
 // ─── Render ───────────────────────────────────────────────────────────────────
 
 export function renderBar(state: GameState, container: HTMLElement, dispatch: Dispatch): void {
-  container.innerHTML = '';
+  container.replaceChildren();
 
   // Reset snack quantities on fresh render.
   for (const s of SNACKS) snackQtys[s.id] = 0;

--- a/src/ui/screens/bodega.ts
+++ b/src/ui/screens/bodega.ts
@@ -34,7 +34,7 @@ const snackQtys: Record<string, number> = {};
 // ─── Render ───────────────────────────────────────────────────────────────────
 
 export function renderBodega(state: GameState, container: HTMLElement, dispatch: Dispatch): void {
-  container.innerHTML = '';
+  container.replaceChildren();
 
   // Reset quantities on fresh render.
   for (const t of TICKET_TYPES) quantities[t.id] = 0;

--- a/src/ui/screens/dads-house.ts
+++ b/src/ui/screens/dads-house.ts
@@ -20,15 +20,11 @@ import {
   getNeighborhoodBar,
 } from '../../data/locations';
 import { getAvailableLoanAmounts, calculateInterestRate } from '../../systems/loan';
-import balance from '../../data/balance.json';
+import { bal } from '../../data/balance-types';
 
 type Dispatch = (action: GameAction) => void;
 
-const dadBal = balance.dadsHouse as {
-  collateralThreshold: number;
-  graveManaRestore: number;
-  graveChillLoss: number;
-};
+const dadBal = bal.dadsHouse;
 
 export function renderDadsHouse(state: GameState, container: HTMLElement, dispatch: Dispatch): void {
   const screen = document.createElement('div');
@@ -53,7 +49,7 @@ export function renderDadsHouse(state: GameState, container: HTMLElement, dispat
   // ── Travel ──
   renderTravelSection(state, screen, dispatch);
 
-  container.innerHTML = '';
+  container.replaceChildren();
   container.appendChild(screen);
 }
 
@@ -105,7 +101,7 @@ function renderDadAlive(state: GameState, screen: HTMLElement, dispatch: Dispatc
     screen.appendChild(makeHeader('REPAY'));
 
     const repayAmounts = [25, 50, 100, 250].filter(
-      a => a <= state.cash && a <= Math.ceil(state.loan!.principal),
+      a => a <= state.cash && state.loan !== null && a <= Math.ceil(state.loan.principal),
     );
     // Always offer "pay all" if affordable.
     const fullAmount = Math.ceil(state.loan.principal);
@@ -119,7 +115,7 @@ function renderDadAlive(state: GameState, screen: HTMLElement, dispatch: Dispatc
     }
 
     for (const amount of repayAmounts) {
-      const label = amount >= Math.ceil(state.loan!.principal)
+      const label = state.loan !== null && amount >= Math.ceil(state.loan.principal)
         ? `REPAY ALL (${formatCash(amount)})`
         : `REPAY ${formatCash(amount)}`;
       screen.appendChild(makeButton(

--- a/src/ui/screens/event.ts
+++ b/src/ui/screens/event.ts
@@ -46,6 +46,6 @@ export function renderEvent(state: GameState, container: HTMLElement, dispatch: 
     ));
   }
 
-  container.innerHTML = '';
+  container.replaceChildren();
   container.appendChild(screen);
 }

--- a/src/ui/screens/furniture-store.ts
+++ b/src/ui/screens/furniture-store.ts
@@ -22,12 +22,12 @@ import {
 } from '../../data/locations';
 import { FURNITURE_CATALOG } from '../../data/furniture';
 import { getBed, hasFurnitureSlot } from '../../systems/furniture';
-import balance from '../../data/balance.json';
+import { bal } from '../../data/balance-types';
 
 type Dispatch = (action: GameAction) => void;
 
 export function renderFurnitureStore(state: GameState, container: HTMLElement, dispatch: Dispatch): void {
-  container.innerHTML = '';
+  container.replaceChildren();
 
   const screen = document.createElement('div');
   screen.className = 'screen furniture-store-screen';
@@ -43,7 +43,7 @@ export function renderFurnitureStore(state: GameState, container: HTMLElement, d
   screen.appendChild(cashRow);
 
   // ── Tower slot count ──
-  const furnitureMax = (balance.furniture as { maxSlots: number }).maxSlots;
+  const furnitureMax = bal.furniture.maxSlots;
   const slotInfo = document.createElement('p');
   slotInfo.className = 'slot-info';
   slotInfo.textContent = `Tower: ${state.furniture.length}/${furnitureMax} slots`;

--- a/src/ui/screens/game-over.ts
+++ b/src/ui/screens/game-over.ts
@@ -39,7 +39,7 @@ function capitalize(s: string): string {
 }
 
 export function renderGameOver(state: GameState, container: HTMLElement, dispatch: Dispatch): void {
-  container.innerHTML = '';
+  container.replaceChildren();
 
   const screen = document.createElement('div');
   screen.className = 'screen game-over-screen';

--- a/src/ui/screens/passout.ts
+++ b/src/ui/screens/passout.ts
@@ -10,7 +10,7 @@ import { formatClock } from '../../engine/time';
 type Dispatch = (action: GameAction) => void;
 
 export function renderPassout(state: GameState, container: HTMLElement, dispatch: Dispatch): void {
-  container.innerHTML = '';
+  container.replaceChildren();
 
   const screen = document.createElement('div');
   screen.className = 'screen passout-screen';

--- a/src/ui/screens/scratch.ts
+++ b/src/ui/screens/scratch.ts
@@ -20,7 +20,7 @@ export function renderScratch(
   container: HTMLElement,
   dispatch: Dispatch,
 ): void {
-  container.innerHTML = '';
+  container.replaceChildren();
   if (!state.scratchSession) return;
 
   const session = state.scratchSession;
@@ -247,7 +247,7 @@ function buildGrid(ticket: GeneratedTicket, dispatch: Dispatch): HTMLElement {
 }
 
 function populateResult(el: HTMLElement, ticket: GeneratedTicket): void {
-  el.innerHTML = '';
+  el.replaceChildren();
   el.appendChild(makeDivider());
 
   if (ticket.isWin) {

--- a/src/ui/screens/setup.ts
+++ b/src/ui/screens/setup.ts
@@ -33,7 +33,7 @@ export function renderSetup(state: GameState, container: HTMLElement, dispatch: 
   // state is needed for the dispatch closure; not used for display here.
   void state;
 
-  container.innerHTML = '';
+  container.replaceChildren();
 
   const screen = document.createElement('div');
   screen.className = 'screen setup-screen';

--- a/src/ui/screens/spell-scroll-store.ts
+++ b/src/ui/screens/spell-scroll-store.ts
@@ -23,18 +23,14 @@ import {
   getNeighborhoodDadsHouse,
   getNeighborhoodBar,
 } from '../../data/locations';
-import balance from '../../data/balance.json';
+import { bal } from '../../data/balance-types';
 
 type Dispatch = (action: GameAction) => void;
 
-const scrollsBal = (balance as Record<string, unknown>).scrolls as {
-  priceByLevel: Record<string, number>;
-  bookstoreMarkup: number;
-  storePurchaseTimeCost: number;
-};
+const scrollsBal = bal.scrolls;
 
 export function renderSpellScrollStore(state: GameState, container: HTMLElement, dispatch: Dispatch): void {
-  container.innerHTML = '';
+  container.replaceChildren();
 
   const screen = document.createElement('div');
   screen.className = 'screen spell-scroll-store-screen';

--- a/src/ui/screens/temple.ts
+++ b/src/ui/screens/temple.ts
@@ -20,17 +20,14 @@ import {
   getNeighborhoodBar,
 } from '../../data/locations';
 import { getGod } from '../../data/gods';
-import balance from '../../data/balance.json';
+import { bal } from '../../data/balance-types';
 
 type Dispatch = (action: GameAction) => void;
 
-const prayerBal = (balance as Record<string, unknown>).prayer as {
-  donationAmounts: number[];
-  durationOptions: number[];
-};
+const prayerBal = bal.prayer;
 
 export function renderTemple(state: GameState, container: HTMLElement, dispatch: Dispatch): void {
-  container.innerHTML = '';
+  container.replaceChildren();
   const screen = document.createElement('div');
   screen.className = 'screen temple-screen';
 

--- a/src/ui/screens/tower.ts
+++ b/src/ui/screens/tower.ts
@@ -28,7 +28,7 @@ import { PROJECTS, getProjectDef } from '../../data/projects';
 import { getProjectProgress, isProjectComplete } from '../../systems/projects';
 import { freeSlots } from '../../systems/inventory';
 import { progressBar } from '../../util/format';
-import balance from '../../data/balance.json';
+import { bal } from '../../data/balance-types';
 
 // Sprint 15: reuse the same timestamp comparison for luck buff display.
 function isLuckBuffActiveNow(state: GameState): boolean {
@@ -43,7 +43,7 @@ function isLuckBuffActiveNow(state: GameState): boolean {
 type Dispatch = (action: GameAction) => void;
 
 export function renderTower(state: GameState, container: HTMLElement, dispatch: Dispatch): void {
-  container.innerHTML = '';
+  container.replaceChildren();
 
   const screen = document.createElement('div');
   screen.className = 'screen tower-screen';
@@ -74,7 +74,7 @@ export function renderTower(state: GameState, container: HTMLElement, dispatch: 
   screen.appendChild(makeSpellbookPanel(state, dispatch));
 
   // ── Furniture (Sprint 13) ──
-  const furnitureMax = (balance.furniture as { maxSlots: number }).maxSlots;
+  const furnitureMax = bal.furniture.maxSlots;
   screen.appendChild(makeFurniturePanel(state, furnitureMax, dispatch));
 
   screen.appendChild(makeDivider());
@@ -438,7 +438,7 @@ function makeCrystalBallPanel(state: GameState, dispatch: Dispatch): HTMLElement
   const panel = document.createElement('div');
   panel.className = 'crystal-ball-panel';
 
-  const crystalBal = (balance as Record<string, unknown>).crystalBall as { revealManaCost: number };
+  const crystalBal = bal.crystalBall;
   const manaCost = crystalBal.revealManaCost;
   const hasAnySpell = CRYSTAL_BALL_REVEALS.some(r => state.knownSpells.includes(r.requiredSpell));
 
@@ -484,10 +484,7 @@ function makeCrystalBallPanel(state: GameState, dispatch: Dispatch): HTMLElement
 
 // ── Project Panel (Sprint 20) ───────────────────────────────────────────────
 
-const projectsBal = (balance as any).projects as {
-  durationOptions: number[];
-  lowChillThreshold: number;
-};
+const projectsBal = bal.projects;
 
 function makeProjectPanel(state: GameState, dispatch: Dispatch): HTMLElement {
   const panel = document.createElement('div');

--- a/src/ui/screens/university-bookstore.ts
+++ b/src/ui/screens/university-bookstore.ts
@@ -23,18 +23,14 @@ import {
   getNeighborhoodDadsHouse,
   getNeighborhoodBar,
 } from '../../data/locations';
-import balance from '../../data/balance.json';
+import { bal } from '../../data/balance-types';
 
 type Dispatch = (action: GameAction) => void;
 
-const scrollsBal = (balance as Record<string, unknown>).scrolls as {
-  priceByLevel: Record<string, number>;
-  bookstoreMarkup: number;
-  storePurchaseTimeCost: number;
-};
+const scrollsBal = bal.scrolls;
 
 export function renderUniversityBookstore(state: GameState, container: HTMLElement, dispatch: Dispatch): void {
-  container.innerHTML = '';
+  container.replaceChildren();
 
   const screen = document.createElement('div');
   screen.className = 'screen university-bookstore-screen';

--- a/src/ui/screens/university.ts
+++ b/src/ui/screens/university.ts
@@ -21,22 +21,18 @@ import {
   getLocationData,
   getLocationNeighborhood,
 } from '../../data/locations';
-import balance from '../../data/balance.json';
+import { bal } from '../../data/balance-types';
 
 type Dispatch = (action: GameAction) => void;
 
-const uniBal = (balance as Record<string, unknown>).university as {
-  openTime: number;
-  closeTime: number;
-  classesPerDay: number;
-};
+const uniBal = bal.university;
 
 export function renderUniversity(
   state: GameState,
   container: HTMLElement,
   dispatch: Dispatch,
 ): void {
-  container.innerHTML = '';
+  container.replaceChildren();
 
   const screen = document.createElement('div');
   screen.className = 'screen university-screen';

--- a/src/util/rng.ts
+++ b/src/util/rng.ts
@@ -23,7 +23,7 @@ export function weightedRandom(
   seed: number,
 ): [index: number, nextSeed: number] {
   const total = weights.reduce((a, b) => a + b, 0);
-  let [r, nextSeed] = rng(seed);
+  let [r, nextSeed] = rng(seed); // eslint-disable-line prefer-const
   r *= total;
   let acc = 0;
   for (let i = 0; i < weights.length; i++) {

--- a/test/systems/spellbook.test.ts
+++ b/test/systems/spellbook.test.ts
@@ -16,7 +16,7 @@ import { getAllSpells } from '../../src/data/spells';
 describe('Sprint 14: Spellbook & University', () => {
   describe('SAVE_VERSION', () => {
     it('is 15', () => {
-      expect(SAVE_VERSION).toBe(15);
+      expect(SAVE_VERSION).toBe(18);
     });
   });
 

--- a/test/systems/stats.test.ts
+++ b/test/systems/stats.test.ts
@@ -5,7 +5,7 @@ import balance from '../../src/data/balance.json';
 describe('Sprint 8: Player Stats', () => {
   describe('SAVE_VERSION', () => {
     it('is 15', () => {
-      expect(SAVE_VERSION).toBe(15);
+      expect(SAVE_VERSION).toBe(18);
     });
   });
 


### PR DESCRIPTION
## Summary

Full senior-dev code review addressing type safety, DOM hygiene, linting, and documentation across 40 files.

- **Typed balance system**: New `balance-types.ts` with `BalanceData` interface eliminates 45+ unsafe `as Record<string, unknown>` and `as any` casts. All files now import `bal` from `balance-types` instead of `balance.json` directly — typos and renamed fields cause compile errors instead of silent runtime bugs.
- **DOM cleanup**: All 18 `innerHTML = ''` occurrences replaced with `replaceChildren()` across every UI file, preventing event listener leaks.
- **ESLint config**: New `.eslintrc.json` with strict rules (`no-explicit-any`, `no-non-null-assertion`, `prefer-const`, etc.) — `npm run lint` now works (was broken with no config).
- **Shared helpers**: Extracted calendar constants + `toTotalMinutes()` in `time.ts` (replaced 3 inline implementations), `addSnacksToInventory()` in `dispatch.ts` (deduplicated BUY_TICKETS/ORDER_DRINK).
- **LLM-agent discoverability**: Added dispatch guide comment, consistent patterns for future sprint work.
- **Bug fixes**: Array mutation in pure function (`spellbook.ts`), non-null assertions without guards (`dads-house.ts`), stale test assertions, lint errors.
- **Documentation**: Complete rewrite of `CLAUDE.md` and updates to `architecture.md` to reflect new patterns.

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npx vitest run` — 127 tests pass
- [x] `npx eslint src --ext .ts` — 0 errors, 7 warnings (pre-existing non-null assertions)
- [ ] Manual smoke test: new game, buy tickets, scratch, travel, sleep, save/load

https://claude.ai/code/session_01MDa9uxULR6LazHngVBC2Wh