### PR TITLE
Streamline game UI: modal popups for all secondary sections

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -123,6 +123,7 @@ html, body {
 /* Sprint 5: Chill bar row */
 .hud-bars {
   display: flex;
+  justify-content: space-between;
   gap: 12px;
 }
 
@@ -521,6 +522,131 @@ html, body {
   min-height: 48px;
   color: var(--fg);
   border-color: var(--border);
+}
+
+/* ─── Compact Stats (redesign) ───────────────────────────────────────────────── */
+
+.stats-compact {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 4px 0;
+}
+
+.stats-labels {
+  display: flex;
+  justify-content: space-between;
+  color: var(--accent);
+  font-size: 0.8em;
+  letter-spacing: 0.04em;
+}
+
+.stats-bars {
+  display: flex;
+  justify-content: space-between;
+  color: var(--bar-fill);
+  font-size: 0.8em;
+  letter-spacing: 0.01em;
+}
+
+/* ─── Modal (redesign) ───────────────────────────────────────────────────────── */
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px;
+}
+
+.modal-box {
+  background: var(--bg);
+  border: 2px solid var(--border);
+  width: 100%;
+  max-width: 460px;
+  max-height: 80vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-title {
+  background: var(--border);
+  color: var(--bg);
+  font-weight: bold;
+  text-align: center;
+  padding: 6px 12px;
+  letter-spacing: 0.08em;
+  font-size: 1em;
+  flex-shrink: 0;
+  font-family: inherit;
+}
+
+.modal-body {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  overflow-y: auto;
+}
+
+.modal-close-btn {
+  width: 100%;
+  font-size: 0.9em;
+  letter-spacing: 0.08em;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+  min-height: 44px;
+  border-left: none;
+  border-right: none;
+  border-bottom: none;
+}
+
+/* ─── Section launch buttons (redesign) ──────────────────────────────────────── */
+
+.section-btn {
+  width: 100%;
+  font-size: 1em;
+  letter-spacing: 0.06em;
+  min-height: 48px;
+  color: var(--accent);
+  border-color: var(--accent);
+  margin-top: 4px;
+}
+
+/* ─── HUD theme buttons (redesign) ───────────────────────────────────────────── */
+
+.hud-theme-btn {
+  background: var(--btn-bg);
+  color: var(--btn-fg);
+  border: 1px solid var(--border);
+  font-family: inherit;
+  font-size: 0.75em;
+  padding: 2px 6px;
+  min-height: 0;
+  min-width: 0;
+  cursor: pointer;
+  line-height: 1.2;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.hud-theme-btn:hover {
+  background: var(--btn-hover);
+}
+
+.hud-theme-btn.active {
+  background: var(--border);
+  color: var(--bg);
+}
+
+.hud-theme-group {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  flex-shrink: 0;
 }
 
 /* ─── Responsive ─────────────────────────────────────────────────────────────── */

--- a/src/ui/components.ts
+++ b/src/ui/components.ts
@@ -1,11 +1,28 @@
 // Reusable DOM component builders.
 // All return HTMLElement instances; no innerHTML string injection.
 
-import type { GameState, InventoryItem, GodId } from '../state/types';
+import type { GameState, InventoryItem, GodId, LocationId } from '../state/types';
+import type { GameAction } from '../engine/actions';
 import { progressBar } from '../util/format';
 import { bal } from '../data/balance-types';
 import { getSpellDef } from '../data/spells';
 import { ALL_GOD_IDS, getGod } from '../data/gods';
+import { formatClock, previewClock } from '../engine/time';
+import { getTravelCostRaw } from '../systems/travel';
+import {
+  NEIGHBORHOODS,
+  getNeighborhoodBodega,
+  getNeighborhoodTemples,
+  getNeighborhoodFurnitureStore,
+  getNeighborhoodUniversity,
+  getNeighborhoodScrollStore,
+  getNeighborhoodBookstore,
+  getNeighborhoodDadsHouse,
+  getNeighborhoodBar,
+  getLocationData,
+} from '../data/locations';
+
+type Dispatch = (action: GameAction) => void;
 
 // ── Button ────────────────────────────────────────────────────────────────────
 
@@ -129,7 +146,7 @@ export function makeResultLine(text: string, className?: string): HTMLElement {
   return p;
 }
 
-// ── Inventory panel ──────────────────────────────────────────────────────
+// ── Inventory panel ──────────────────────────────────────────────────────────
 // Reusable panel showing current inventory with EAT buttons for snacks
 // and USE buttons for spell scrolls.
 
@@ -179,6 +196,11 @@ export function makeInventoryPanel(
           panel.appendChild(useBtn);
         }
       }
+    } else if (item && item.type === 'monument') {
+      const el = document.createElement('p');
+      el.className = 'inv-monument';
+      el.textContent = item.name;
+      panel.appendChild(el);
     } else {
       const el = document.createElement('p');
       el.className = 'inv-empty';
@@ -190,29 +212,151 @@ export function makeInventoryPanel(
   return panel;
 }
 
-// ── Stats panel ──────────────────────────────────────────────────────────
-// Reusable panel showing player stats as progress bars (no numeric values).
+// ── Stats panel ──────────────────────────────────────────────────────────────
+// Compact 2-row layout: labels row + bars row. No header label.
 
 export function makeStatsPanel(state: GameState): HTMLElement {
   const panel = document.createElement('div');
   panel.className = 'stats-panel';
 
-  panel.appendChild(makeHeader('STATS'));
-
   const dm = bal.stats.displayMax;
   const stats: Array<{ label: string; value: number; max: number }> = [
-    { label: 'INT ', value: state.intelligence,      max: dm.intelligence },
+    { label: 'INT',  value: state.intelligence,      max: dm.intelligence },
     { label: 'BIND', value: state.bookbinding,       max: dm.bookbinding },
     { label: 'FAME', value: state.wizardFame,        max: dm.wizardFame },
     { label: 'RELX', value: state.relaxationRate,    max: dm.relaxationRate },
     { label: 'REST', value: state.restingRelaxation, max: dm.restingRelaxation },
   ];
 
+  const compact = document.createElement('div');
+  compact.className = 'stats-compact';
+
+  const labelsRow = document.createElement('div');
+  labelsRow.className = 'stats-labels';
+
+  const barsRow = document.createElement('div');
+  barsRow.className = 'stats-bars';
+
   for (const s of stats) {
-    const row = document.createElement('p');
-    row.className = 'stat-row';
-    row.textContent = `${s.label} ${progressBar(s.value, s.max, 20)}`;
-    panel.appendChild(row);
+    const lbl = document.createElement('span');
+    lbl.textContent = s.label;
+    labelsRow.appendChild(lbl);
+
+    const bar = document.createElement('span');
+    bar.textContent = progressBar(s.value, s.max, 8);
+    barsRow.appendChild(bar);
+  }
+
+  compact.appendChild(labelsRow);
+  compact.appendChild(barsRow);
+  panel.appendChild(compact);
+
+  return panel;
+}
+
+// ── Modal ─────────────────────────────────────────────────────────────────────
+// DOS-style overlay with inverted title bar. Tap outside or CLOSE to dismiss.
+
+export function makeModal(title: string, body: HTMLElement, onClose: () => void): HTMLElement {
+  const overlay = document.createElement('div');
+  overlay.className = 'modal-overlay';
+
+  const box = document.createElement('div');
+  box.className = 'modal-box';
+
+  const titleEl = document.createElement('div');
+  titleEl.className = 'modal-title';
+  titleEl.textContent = title;
+
+  const bodyEl = document.createElement('div');
+  bodyEl.className = 'modal-body';
+  bodyEl.appendChild(body);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'btn modal-close-btn';
+  closeBtn.textContent = '[ CLOSE ]';
+  closeBtn.addEventListener('click', onClose);
+
+  // Tap outside the box to close.
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) onClose();
+  });
+
+  box.appendChild(titleEl);
+  box.appendChild(bodyEl);
+  box.appendChild(closeBtn);
+  overlay.appendChild(box);
+
+  return overlay;
+}
+
+// ── Travel panel ──────────────────────────────────────────────────────────────
+// Shared travel destination list used by all location screens via TRAVEL modal.
+// Filters out state.currentLocation. If at tower, no TOWER HOME button.
+// Uses neighborhood-label + individual-button layout throughout for consistency.
+
+export function makeTravelPanel(state: GameState, dispatch: Dispatch): HTMLElement {
+  const panel = document.createElement('div');
+  panel.className = 'travel-panel';
+
+  const currentLoc = state.currentLocation;
+  const isAtTower = currentLoc === 'tower';
+
+  // TOWER (HOME) — shown from all non-tower locations.
+  if (!isAtTower) {
+    const towerLoc = 'tower' as LocationId;
+    const cost = getTravelCostRaw(currentLoc, towerLoc);
+    const clock = previewClock(state.clock, cost);
+    panel.appendChild(makeButton(
+      `TOWER (HOME)  \u2192  ${formatClock(clock)}`,
+      () => dispatch({ type: 'TRAVEL', destination: towerLoc }),
+      'nav-btn',
+    ));
+  }
+
+  // Per-neighborhood sections.
+  for (const neighborhood of NEIGHBORHOODS) {
+    const bodegaId = getNeighborhoodBodega(neighborhood.id);
+    const temples = getNeighborhoodTemples(neighborhood.id);
+    const fsId = getNeighborhoodFurnitureStore(neighborhood.id);
+    const uniId = getNeighborhoodUniversity(neighborhood.id);
+    const ssId = getNeighborhoodScrollStore(neighborhood.id);
+    const bsId = getNeighborhoodBookstore(neighborhood.id);
+    const dhId = getNeighborhoodDadsHouse(neighborhood.id);
+    const barId = getNeighborhoodBar(neighborhood.id);
+
+    const destinations: LocationId[] = [
+      bodegaId,
+      ...temples.map(t => t.id),
+      fsId,
+      ...(uniId ? [uniId] : []),
+      ssId,
+      ...(bsId ? [bsId] : []),
+      ...(dhId ? [dhId] : []),
+      ...(barId ? [barId] : []),
+    ].filter(id => id !== currentLoc);
+
+    if (destinations.length === 0) continue;
+
+    const nbLabel = document.createElement('p');
+    nbLabel.className = 'neighborhood-label';
+    nbLabel.textContent = neighborhood.name.toUpperCase();
+    panel.appendChild(nbLabel);
+
+    for (const destId of destinations) {
+      const destData = getLocationData(destId);
+      const cost = getTravelCostRaw(currentLoc, destId);
+      const clock = previewClock(state.clock, cost);
+      // Dad's house uses "DAD'S GRAVE" label when dad has passed.
+      const displayName = (destId === dhId && !state.dadAlive)
+        ? "DAD'S GRAVE"
+        : destData.displayName;
+      panel.appendChild(makeButton(
+        `${displayName}  \u2192  ${formatClock(clock)}`,
+        () => dispatch({ type: 'TRAVEL', destination: destId }),
+        'nav-btn',
+      ));
+    }
   }
 
   return panel;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1,15 +1,19 @@
 // Persistent HUD bar — always visible above the screen area.
 // Sprint 2: shows Cash, Clock, and Calendar.
 // Sprint 5: adds Chill bar. Sprint 6+: adds Mana bar.
+// Redesign: theme toggle (BLU/GRN/AMB) moved here from tower screen.
 
 import type { GameState } from '../state/types';
+import type { GameAction } from '../engine/actions';
 import { formatCash, progressBar } from '../util/format';
 import { formatClock, formatDate } from '../engine/time';
 
-export function renderHUD(state: GameState, el: HTMLElement): void {
+type Dispatch = (action: GameAction) => void;
+
+export function renderHUD(state: GameState, el: HTMLElement, dispatch: Dispatch): void {
   el.className = 'hud';
 
-  // ── Row 1: Cash | Clock | Date ──
+  // ── Row 1: Cash | Clock | Theme toggle ──
   const row1 = document.createElement('div');
   row1.className = 'hud-row';
 
@@ -21,26 +25,45 @@ export function renderHUD(state: GameState, el: HTMLElement): void {
   clockEl.className = 'hud-clock';
   clockEl.textContent = formatClock(state.clock);
 
+  // Theme toggle (BLU / GRN / AMB) — small buttons, deliberately not using .btn
+  // to avoid its 44px min-height bloating the HUD row.
+  const themeGroup = document.createElement('div');
+  themeGroup.className = 'hud-theme-group';
+
+  const themes: Array<{ scheme: GameState['colorScheme']; label: string }> = [
+    { scheme: 'blue',   label: 'BLU' },
+    { scheme: 'green',  label: 'GRN' },
+    { scheme: 'orange', label: 'AMB' },
+  ];
+  for (const { scheme, label } of themes) {
+    const btn = document.createElement('button');
+    btn.className = `hud-theme-btn${state.colorScheme === scheme ? ' active' : ''}`;
+    btn.textContent = label;
+    btn.addEventListener('click', () => dispatch({ type: 'SET_THEME', scheme }));
+    themeGroup.appendChild(btn);
+  }
+
+  row1.appendChild(cashEl);
+  row1.appendChild(clockEl);
+  row1.appendChild(themeGroup);
+
+  // ── Row 2: Date | Chill bar | Mana bar ──
+  const row2 = document.createElement('div');
+  row2.className = 'hud-bars';
+
   const dateEl = document.createElement('span');
   dateEl.className = 'hud-date';
   dateEl.textContent = formatDate(state.day, state.month, state.year);
 
-  row1.appendChild(cashEl);
-  row1.appendChild(clockEl);
-  row1.appendChild(dateEl);
-
-  // ── Row 2: Chill & Mana bars ──
-  const row2 = document.createElement('div');
-  row2.className = 'hud-bars';
-
   const chillEl = document.createElement('span');
   chillEl.className = 'hud-chill';
-  chillEl.textContent = `CHILL ${progressBar(state.chill, 100, 20)}`;
+  chillEl.textContent = `CHILL ${progressBar(state.chill, 100, 16)}`;
 
   const manaEl = document.createElement('span');
   manaEl.className = 'hud-mana';
-  manaEl.textContent = `MANA  ${progressBar(state.mana, state.maxMana, 20)}`;
+  manaEl.textContent = `MANA ${progressBar(state.mana, state.maxMana, 16)}`;
 
+  row2.appendChild(dateEl);
   row2.appendChild(chillEl);
   row2.appendChild(manaEl);
 

--- a/src/ui/modal.ts
+++ b/src/ui/modal.ts
@@ -1,0 +1,26 @@
+// Shared modal state manager.
+// Each screen tracks its own open modal by screen ID.
+// renderer.ts calls resetAllModals() on screen transitions so modals don't
+// persist when the player navigates away and returns later.
+
+const _state: Record<string, string | null> = {};
+
+export function getModal(screenId: string): string | null {
+  return _state[screenId] ?? null;
+}
+
+export function openModal(screenId: string, modalId: string, rerender: () => void): void {
+  _state[screenId] = modalId;
+  rerender();
+}
+
+export function closeModal(screenId: string, rerender: () => void): void {
+  _state[screenId] = null;
+  rerender();
+}
+
+export function resetAllModals(): void {
+  for (const key of Object.keys(_state)) {
+    _state[key] = null;
+  }
+}

--- a/src/ui/renderer.ts
+++ b/src/ui/renderer.ts
@@ -5,6 +5,7 @@
 import type { GameState } from '../state/types';
 import type { GameAction } from '../engine/actions';
 import { renderHUD } from './hud';
+import { resetAllModals } from './modal';
 import { renderBodega } from './screens/bodega';
 import { renderScratch, updateScratchCell } from './screens/scratch';
 import { renderTower } from './screens/tower';
@@ -94,9 +95,14 @@ export function render(
   const { hud, screen } = ensureLayout(container);
 
   // HUD always re-renders (it's fast text — no perf concern).
-  renderHUD(state, hud);
+  renderHUD(state, hud, dispatch);
 
   const targetScreen = getTargetScreen(state);
+
+  // Reset all modal state when navigating to a different screen.
+  if (targetScreen !== currentScreen) {
+    resetAllModals();
+  }
 
   if (targetScreen === 'setup') {
     currentScreen = 'setup';

--- a/src/ui/screens/bar.ts
+++ b/src/ui/screens/bar.ts
@@ -1,5 +1,6 @@
 // University Bar screen: order drinks (immediate chill/mana effect) and buy snacks for inventory.
 // Sprint 25: University Heights only.
+// Redesign: INVENTORY and TRAVEL moved to modal popups.
 
 import type { GameState } from '../../state/types';
 import type { GameAction } from '../../engine/actions';
@@ -7,25 +8,17 @@ import { DRINKS } from '../../data/drinks';
 import { SNACKS } from '../../data/food';
 import { formatCash } from '../../util/format';
 import {
-  makeButton, makeHeader, makeCashBar, makeQuantityRow, makeDivider, makeInventoryPanel,
+  makeButton, makeHeader, makeCashBar, makeQuantityRow, makeDivider,
+  makeInventoryPanel, makeModal, makeTravelPanel,
 } from '../components';
 import { formatClock, previewClock } from '../../engine/time';
-import { getTravelCostRaw } from '../../systems/travel';
 import { freeSlots } from '../../systems/inventory';
-import {
-  getLocationData,
-  getLocationNeighborhood,
-  NEIGHBORHOODS,
-  getNeighborhoodBodega,
-  getNeighborhoodTemples,
-  getNeighborhoodFurnitureStore,
-  getNeighborhoodUniversity,
-  getNeighborhoodScrollStore,
-  getNeighborhoodBookstore,
-  getNeighborhoodDadsHouse,
-} from '../../data/locations';
+import { getLocationData } from '../../data/locations';
+import { getModal, openModal, closeModal } from '../modal';
 
 type Dispatch = (action: GameAction) => void;
+
+const SCREEN = 'university_bar';
 
 // Local snack quantity state (UI-only, reset on each render).
 const snackQtys: Record<string, number> = {};
@@ -131,196 +124,45 @@ export function renderBar(state: GameState, container: HTMLElement, dispatch: Di
   invWarning.style.display = 'none';
   screen.appendChild(invWarning);
 
+  // ── Section buttons ──
   screen.appendChild(makeDivider());
 
-  // ── Inventory panel ──
-  screen.appendChild(
-    makeInventoryPanel(
-      state.inventory,
-      (slotIndex) => dispatch({ type: 'CONSUME_SNACK', slotIndex }),
-      (slotIndex, godId) => dispatch({ type: 'USE_SCROLL', slotIndex, godId }),
-    ),
-  );
-
-  // ── Travel section ──
-  screen.appendChild(makeDivider());
-  screen.appendChild(makeHeader('TRAVEL'));
-
-  // Tower always first.
-  const towerCost = getTravelCostRaw(state.currentLocation, 'tower');
-  const towerClock = previewClock(state.clock, towerCost);
+  const invCount = state.inventory.filter(i => i !== null).length;
   screen.appendChild(makeButton(
-    `TOWER (HOME)  \u2192  ${formatClock(towerClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: 'tower' }),
-    'nav-btn',
+    `INVENTORY (${invCount}/${state.inventory.length})`,
+    () => openModal(SCREEN, 'inventory', () => renderBar(state, container, dispatch)),
+    'section-btn',
   ));
 
-  const currentNeighborhood = getLocationNeighborhood(state.currentLocation);
-
-  // Other neighborhoods.
-  for (const neighborhood of NEIGHBORHOODS) {
-    if (neighborhood.id === currentNeighborhood) continue;
-
-    const destId = getNeighborhoodBodega(neighborhood.id);
-    const destData = getLocationData(destId);
-    const cost = getTravelCostRaw(state.currentLocation, destId);
-    const arrival = previewClock(state.clock, cost);
-    screen.appendChild(makeButton(
-      `${neighborhood.name.toUpperCase()}: ${destData.displayName}  \u2192  ${formatClock(arrival)}`,
-      () => dispatch({ type: 'TRAVEL', destination: destId }),
-      'nav-btn',
-    ));
-
-    const temples = getNeighborhoodTemples(neighborhood.id);
-    for (const temple of temples) {
-      const tCost = getTravelCostRaw(state.currentLocation, temple.id);
-      const tClock = previewClock(state.clock, tCost);
-      screen.appendChild(makeButton(
-        `${temple.displayName}  \u2192  ${formatClock(tClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: temple.id }),
-        'nav-btn',
-      ));
-    }
-
-    const fsId = getNeighborhoodFurnitureStore(neighborhood.id);
-    const fsData = getLocationData(fsId);
-    const fsCost = getTravelCostRaw(state.currentLocation, fsId);
-    const fsClock = previewClock(state.clock, fsCost);
-    screen.appendChild(makeButton(
-      `${fsData.displayName}  \u2192  ${formatClock(fsClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: fsId }),
-      'nav-btn',
-    ));
-
-    const uniId = getNeighborhoodUniversity(neighborhood.id);
-    if (uniId) {
-      const uniData = getLocationData(uniId);
-      const uniCost = getTravelCostRaw(state.currentLocation, uniId);
-      const uniClock = previewClock(state.clock, uniCost);
-      screen.appendChild(makeButton(
-        `${uniData.displayName}  \u2192  ${formatClock(uniClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: uniId }),
-        'nav-btn',
-      ));
-    }
-
-    const ssId = getNeighborhoodScrollStore(neighborhood.id);
-    const ssData = getLocationData(ssId);
-    const ssCost = getTravelCostRaw(state.currentLocation, ssId);
-    const ssClock = previewClock(state.clock, ssCost);
-    screen.appendChild(makeButton(
-      `${ssData.displayName}  \u2192  ${formatClock(ssClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: ssId }),
-      'nav-btn',
-    ));
-
-    const bsId = getNeighborhoodBookstore(neighborhood.id);
-    if (bsId) {
-      const bsData = getLocationData(bsId);
-      const bsCost = getTravelCostRaw(state.currentLocation, bsId);
-      const bsClock = previewClock(state.clock, bsCost);
-      screen.appendChild(makeButton(
-        `${bsData.displayName}  \u2192  ${formatClock(bsClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: bsId }),
-        'nav-btn',
-      ));
-    }
-
-    const dhId = getNeighborhoodDadsHouse(neighborhood.id);
-    if (dhId && dhId !== state.currentLocation) {
-      const dhData = getLocationData(dhId);
-      const dhCost = getTravelCostRaw(state.currentLocation, dhId);
-      const dhClock = previewClock(state.clock, dhCost);
-      const dhLabel = state.dadAlive ? dhData.displayName : "DAD'S GRAVE";
-      screen.appendChild(makeButton(
-        `${dhLabel}  \u2192  ${formatClock(dhClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: dhId }),
-        'nav-btn',
-      ));
-    }
-  }
-
-  // Local neighborhood (University Heights — show everything except the bar itself).
-  const localBodega = getNeighborhoodBodega(currentNeighborhood);
-  const localBodegaData = getLocationData(localBodega);
-  const lbCost = getTravelCostRaw(state.currentLocation, localBodega);
-  const lbClock = previewClock(state.clock, lbCost);
   screen.appendChild(makeButton(
-    `${localBodegaData.displayName}  \u2192  ${formatClock(lbClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: localBodega }),
-    'nav-btn',
+    'TRAVEL',
+    () => openModal(SCREEN, 'travel', () => renderBar(state, container, dispatch)),
+    'section-btn',
   ));
-
-  const localTemples = getNeighborhoodTemples(currentNeighborhood);
-  for (const temple of localTemples) {
-    const tCost = getTravelCostRaw(state.currentLocation, temple.id);
-    const tClock = previewClock(state.clock, tCost);
-    screen.appendChild(makeButton(
-      `${temple.displayName}  \u2192  ${formatClock(tClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: temple.id }),
-      'nav-btn',
-    ));
-  }
-
-  const localFsId = getNeighborhoodFurnitureStore(currentNeighborhood);
-  const localFsData = getLocationData(localFsId);
-  const localFsCost = getTravelCostRaw(state.currentLocation, localFsId);
-  const localFsClock = previewClock(state.clock, localFsCost);
-  screen.appendChild(makeButton(
-    `${localFsData.displayName}  \u2192  ${formatClock(localFsClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: localFsId }),
-    'nav-btn',
-  ));
-
-  const localUniId = getNeighborhoodUniversity(currentNeighborhood);
-  if (localUniId) {
-    const localUniData = getLocationData(localUniId);
-    const localUniCost = getTravelCostRaw(state.currentLocation, localUniId);
-    const localUniClock = previewClock(state.clock, localUniCost);
-    screen.appendChild(makeButton(
-      `${localUniData.displayName}  \u2192  ${formatClock(localUniClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: localUniId }),
-      'nav-btn',
-    ));
-  }
-
-  const localSsId = getNeighborhoodScrollStore(currentNeighborhood);
-  const localSsData = getLocationData(localSsId);
-  const localSsCost = getTravelCostRaw(state.currentLocation, localSsId);
-  const localSsClock = previewClock(state.clock, localSsCost);
-  screen.appendChild(makeButton(
-    `${localSsData.displayName}  \u2192  ${formatClock(localSsClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: localSsId }),
-    'nav-btn',
-  ));
-
-  const localBsId = getNeighborhoodBookstore(currentNeighborhood);
-  if (localBsId) {
-    const localBsData = getLocationData(localBsId);
-    const localBsCost = getTravelCostRaw(state.currentLocation, localBsId);
-    const localBsClock = previewClock(state.clock, localBsCost);
-    screen.appendChild(makeButton(
-      `${localBsData.displayName}  \u2192  ${formatClock(localBsClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: localBsId }),
-      'nav-btn',
-    ));
-  }
-
-  const localDhId = getNeighborhoodDadsHouse(currentNeighborhood);
-  if (localDhId && localDhId !== state.currentLocation) {
-    const localDhData = getLocationData(localDhId);
-    const localDhCost = getTravelCostRaw(state.currentLocation, localDhId);
-    const localDhClock = previewClock(state.clock, localDhCost);
-    const localDhLabel = state.dadAlive ? localDhData.displayName : "DAD'S GRAVE";
-    screen.appendChild(makeButton(
-      `${localDhLabel}  \u2192  ${formatClock(localDhClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: localDhId }),
-      'nav-btn',
-    ));
-  }
-  // (Self — the bar — is omitted from travel section.)
 
   container.appendChild(screen);
+
+  // ── Active modal ──
+  const activeModal = getModal(SCREEN);
+  if (activeModal !== null) {
+    const onClose = () => closeModal(SCREEN, () => renderBar(state, container, dispatch));
+    let body: HTMLElement;
+    let title: string;
+
+    if (activeModal === 'inventory') {
+      title = 'INVENTORY';
+      body = makeInventoryPanel(
+        state.inventory,
+        (slotIndex) => dispatch({ type: 'CONSUME_SNACK', slotIndex }),
+        (slotIndex, godId) => dispatch({ type: 'USE_SCROLL', slotIndex, godId }),
+      );
+    } else {
+      title = 'TRAVEL';
+      body = makeTravelPanel(state, dispatch);
+    }
+
+    container.appendChild(makeModal(title, body, onClose));
+  }
 
   // ── Helpers ──
   function projectedSnackCost(): number {

--- a/src/ui/screens/bodega.ts
+++ b/src/ui/screens/bodega.ts
@@ -1,31 +1,25 @@
 // Bodega screen: buy scratch-off tickets and snacks.
 // Sprint 4: store name is dynamic per neighborhood; travel section lists all other destinations.
 // Sprint 7: snack purchasing with inventory warnings + inventory panel with EAT.
+// Redesign: INVENTORY and TRAVEL moved to modal popups.
 
 import type { GameState } from '../../state/types';
 import type { GameAction } from '../../engine/actions';
 import { TICKET_TYPES } from '../../data/tickets';
 import { SNACKS } from '../../data/food';
 import { formatCash, calcScratchTimeCost } from '../../util/format';
-import { makeButton, makeHeader, makeCashBar, makeQuantityRow, makeDivider, makeInventoryPanel } from '../components';
-import { formatClock, previewClock } from '../../engine/time';
-import { getTravelCostRaw } from '../../systems/travel';
-import { freeSlots } from '../../systems/inventory';
 import {
-  getLocationData,
-  getLocationNeighborhood,
-  NEIGHBORHOODS,
-  getNeighborhoodBodega,
-  getNeighborhoodTemples,
-  getNeighborhoodFurnitureStore,
-  getNeighborhoodUniversity,
-  getNeighborhoodScrollStore,
-  getNeighborhoodBookstore,
-  getNeighborhoodDadsHouse,
-  getNeighborhoodBar,
-} from '../../data/locations';
+  makeButton, makeHeader, makeCashBar, makeQuantityRow, makeDivider,
+  makeInventoryPanel, makeModal, makeTravelPanel,
+} from '../components';
+import { formatClock } from '../../engine/time';
+import { freeSlots } from '../../systems/inventory';
+import { getLocationData } from '../../data/locations';
+import { getModal, openModal, closeModal } from '../modal';
 
 type Dispatch = (action: GameAction) => void;
+
+const SCREEN = 'bodega';
 
 // Local mutable quantity state (not in GameState — just UI state before purchase).
 const quantities: Record<string, number> = {};
@@ -88,9 +82,6 @@ export function renderBodega(state: GameState, container: HTMLElement, dispatch:
   // ── Snack list (Sprint 7) ──
   screen.appendChild(makeHeader('SNACKS'));
 
-  // Track snack +/- updaters so we can disable when full.
-  const snackUpdaters: Array<{ updateQty: (n: number) => void }> = [];
-
   for (const snack of SNACKS) {
     const { row, updateQty } = makeQuantityRow(
       snack.name,
@@ -117,7 +108,6 @@ export function renderBodega(state: GameState, container: HTMLElement, dispatch:
         },
       },
     );
-    snackUpdaters.push({ updateQty });
     screen.appendChild(row);
   }
 
@@ -165,212 +155,43 @@ export function renderBodega(state: GameState, container: HTMLElement, dispatch:
   buyBtn.id = 'buy-btn';
   screen.appendChild(buyBtn);
 
-  // ── Inventory panel (Sprint 7) ──
-  screen.appendChild(makeDivider());
-  screen.appendChild(
-    makeInventoryPanel(
-      state.inventory,
-      (slotIndex) => dispatch({ type: 'CONSUME_SNACK', slotIndex }),
-      (slotIndex, godId) => dispatch({ type: 'USE_SCROLL', slotIndex, godId }),
-    ),
-  );
-
-  // ── Travel section ──
-  screen.appendChild(makeDivider());
-  screen.appendChild(makeHeader('TRAVEL'));
-
-  // Tower (home) always first.
-  const towerCost = getTravelCostRaw(state.currentLocation, 'tower');
-  const towerClock = previewClock(state.clock, towerCost);
-  const returnBtn = makeButton(
-    `TOWER (HOME)  \u2192  ${formatClock(towerClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: 'tower' }),
-    'nav-btn',
-  );
-  screen.appendChild(returnBtn);
-
-  // Other neighborhoods' bodegas, temples, and stores (skip the current neighborhood's bodega).
-  const currentNeighborhood = getLocationNeighborhood(state.currentLocation);
-  for (const neighborhood of NEIGHBORHOODS) {
-    if (neighborhood.id === currentNeighborhood) continue;
-    const destId = getNeighborhoodBodega(neighborhood.id);
-    const destData = getLocationData(destId);
-    const cost = getTravelCostRaw(state.currentLocation, destId);
-    const arrival = previewClock(state.clock, cost);
-    const btn = makeButton(
-      `${neighborhood.name.toUpperCase()}: ${destData.displayName}  \u2192  ${formatClock(arrival)}`,
-      () => dispatch({ type: 'TRAVEL', destination: destId }),
-      'nav-btn',
-    );
-    screen.appendChild(btn);
-
-    const temples = getNeighborhoodTemples(neighborhood.id);
-    for (const temple of temples) {
-      const tCost = getTravelCostRaw(state.currentLocation, temple.id);
-      const tClock = previewClock(state.clock, tCost);
-      screen.appendChild(makeButton(
-        `${temple.displayName}  \u2192  ${formatClock(tClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: temple.id }),
-        'nav-btn',
-      ));
-    }
-
-    const fsId = getNeighborhoodFurnitureStore(neighborhood.id);
-    const fsData = getLocationData(fsId);
-    const fsCost = getTravelCostRaw(state.currentLocation, fsId);
-    const fsClock = previewClock(state.clock, fsCost);
-    screen.appendChild(makeButton(
-      `${fsData.displayName}  \u2192  ${formatClock(fsClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: fsId }),
-      'nav-btn',
-    ));
-
-    const uniId = getNeighborhoodUniversity(neighborhood.id);
-    if (uniId) {
-      const uniData = getLocationData(uniId);
-      const uniCost = getTravelCostRaw(state.currentLocation, uniId);
-      const uniClock = previewClock(state.clock, uniCost);
-      screen.appendChild(makeButton(
-        `${uniData.displayName}  \u2192  ${formatClock(uniClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: uniId }),
-        'nav-btn',
-      ));
-    }
-
-    const ssId = getNeighborhoodScrollStore(neighborhood.id);
-    const ssData = getLocationData(ssId);
-    const ssCost = getTravelCostRaw(state.currentLocation, ssId);
-    const ssClock = previewClock(state.clock, ssCost);
-    screen.appendChild(makeButton(
-      `${ssData.displayName}  \u2192  ${formatClock(ssClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: ssId }),
-      'nav-btn',
-    ));
-
-    const bsId = getNeighborhoodBookstore(neighborhood.id);
-    if (bsId) {
-      const bsData = getLocationData(bsId);
-      const bsCost = getTravelCostRaw(state.currentLocation, bsId);
-      const bsClock = previewClock(state.clock, bsCost);
-      screen.appendChild(makeButton(
-        `${bsData.displayName}  \u2192  ${formatClock(bsClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: bsId }),
-        'nav-btn',
-      ));
-    }
-
-    // Dad's House (Richville only)
-    const dhId = getNeighborhoodDadsHouse(neighborhood.id);
-    if (dhId && dhId !== state.currentLocation) {
-      const dhData = getLocationData(dhId);
-      const dhCost = getTravelCostRaw(state.currentLocation, dhId);
-      const dhClock = previewClock(state.clock, dhCost);
-      const dhLabel = state.dadAlive ? dhData.displayName : "DAD'S GRAVE";
-      screen.appendChild(makeButton(
-        `${dhLabel}  \u2192  ${formatClock(dhClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: dhId }),
-        'nav-btn',
-      ));
-    }
-
-    // Sprint 25: University Bar (University Heights only)
-    const barId = getNeighborhoodBar(neighborhood.id);
-    if (barId) {
-      const barData = getLocationData(barId);
-      const barCost = getTravelCostRaw(state.currentLocation, barId);
-      const barClock = previewClock(state.clock, barCost);
-      screen.appendChild(makeButton(
-        `${barData.displayName}  \u2192  ${formatClock(barClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: barId }),
-        'nav-btn',
-      ));
-    }
-  }
-
-  // Local neighborhood locations (temples, furniture store, university if any, scroll store, bookstore if any).
-  const localTemples = getNeighborhoodTemples(currentNeighborhood);
-  for (const temple of localTemples) {
-    const tCost = getTravelCostRaw(state.currentLocation, temple.id);
-    const tClock = previewClock(state.clock, tCost);
-    screen.appendChild(makeButton(
-      `${temple.displayName}  \u2192  ${formatClock(tClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: temple.id }),
-      'nav-btn',
-    ));
-  }
-
-  const localFsId = getNeighborhoodFurnitureStore(currentNeighborhood);
-  const localFsData = getLocationData(localFsId);
-  const localFsCost = getTravelCostRaw(state.currentLocation, localFsId);
-  const localFsClock = previewClock(state.clock, localFsCost);
+  // ── Section buttons ──
+  const invCount = state.inventory.filter(i => i !== null).length;
   screen.appendChild(makeButton(
-    `${localFsData.displayName}  \u2192  ${formatClock(localFsClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: localFsId }),
-    'nav-btn',
+    `INVENTORY (${invCount}/${state.inventory.length})`,
+    () => openModal(SCREEN, 'inventory', () => renderBodega(state, container, dispatch)),
+    'section-btn',
   ));
 
-  const localUniId = getNeighborhoodUniversity(currentNeighborhood);
-  if (localUniId) {
-    const localUniData = getLocationData(localUniId);
-    const localUniCost = getTravelCostRaw(state.currentLocation, localUniId);
-    const localUniClock = previewClock(state.clock, localUniCost);
-    screen.appendChild(makeButton(
-      `${localUniData.displayName}  \u2192  ${formatClock(localUniClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: localUniId }),
-      'nav-btn',
-    ));
-  }
-
-  const localSsId = getNeighborhoodScrollStore(currentNeighborhood);
-  const localSsData = getLocationData(localSsId);
-  const localSsCost = getTravelCostRaw(state.currentLocation, localSsId);
-  const localSsClock = previewClock(state.clock, localSsCost);
   screen.appendChild(makeButton(
-    `${localSsData.displayName}  \u2192  ${formatClock(localSsClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: localSsId }),
-    'nav-btn',
+    'TRAVEL',
+    () => openModal(SCREEN, 'travel', () => renderBodega(state, container, dispatch)),
+    'section-btn',
   ));
-
-  const localBsId = getNeighborhoodBookstore(currentNeighborhood);
-  if (localBsId) {
-    const localBsData = getLocationData(localBsId);
-    const localBsCost = getTravelCostRaw(state.currentLocation, localBsId);
-    const localBsClock = previewClock(state.clock, localBsCost);
-    screen.appendChild(makeButton(
-      `${localBsData.displayName}  \u2192  ${formatClock(localBsClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: localBsId }),
-      'nav-btn',
-    ));
-  }
-
-  // Dad's House (Richville only)
-  const localDhId = getNeighborhoodDadsHouse(currentNeighborhood);
-  if (localDhId && localDhId !== state.currentLocation) {
-    const localDhData = getLocationData(localDhId);
-    const localDhCost = getTravelCostRaw(state.currentLocation, localDhId);
-    const localDhClock = previewClock(state.clock, localDhCost);
-    const localDhLabel = state.dadAlive ? localDhData.displayName : "DAD'S GRAVE";
-    screen.appendChild(makeButton(
-      `${localDhLabel}  \u2192  ${formatClock(localDhClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: localDhId }),
-      'nav-btn',
-    ));
-  }
-
-  // Sprint 25: University Bar (University Heights only)
-  const localBarId = getNeighborhoodBar(currentNeighborhood);
-  if (localBarId && localBarId !== state.currentLocation) {
-    const localBarData = getLocationData(localBarId);
-    const localBarCost = getTravelCostRaw(state.currentLocation, localBarId);
-    const localBarClock = previewClock(state.clock, localBarCost);
-    screen.appendChild(makeButton(
-      `${localBarData.displayName}  \u2192  ${formatClock(localBarClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: localBarId }),
-      'nav-btn',
-    ));
-  }
 
   container.appendChild(screen);
+
+  // ── Active modal ──
+  const activeModal = getModal(SCREEN);
+  if (activeModal !== null) {
+    const onClose = () => closeModal(SCREEN, () => renderBodega(state, container, dispatch));
+    let body: HTMLElement;
+    let title: string;
+
+    if (activeModal === 'inventory') {
+      title = 'INVENTORY';
+      body = makeInventoryPanel(
+        state.inventory,
+        (slotIndex) => dispatch({ type: 'CONSUME_SNACK', slotIndex }),
+        (slotIndex, godId) => dispatch({ type: 'USE_SCROLL', slotIndex, godId }),
+      );
+    } else {
+      title = 'TRAVEL';
+      body = makeTravelPanel(state, dispatch);
+    }
+
+    container.appendChild(makeModal(title, body, onClose));
+  }
 
   // ── Helpers ──
   function projectedCost(): number {

--- a/src/ui/screens/dads-house.ts
+++ b/src/ui/screens/dads-house.ts
@@ -1,29 +1,21 @@
 // Dad's House screen (Sprint 22).
 // When dadAlive: loan interface. When !dadAlive: Dad's Grave (visit for mana/chill).
+// Redesign: INVENTORY and TRAVEL moved to modal popups.
 
 import type { GameState } from '../../state/types';
 import type { GameAction } from '../../engine/actions';
-import { makeButton, makeHeader, makeDivider, makeInventoryPanel, makeResultLine } from '../components';
-import { formatCash } from '../../util/format';
-import { formatClock, previewClock } from '../../engine/time';
-import { getTravelCostRaw } from '../../systems/travel';
 import {
-  getLocationData,
-  getNeighborhoodTemples,
-  NEIGHBORHOODS,
-  getNeighborhoodBodega,
-  getNeighborhoodFurnitureStore,
-  getNeighborhoodUniversity,
-  getNeighborhoodScrollStore,
-  getNeighborhoodBookstore,
-  getNeighborhoodDadsHouse,
-  getNeighborhoodBar,
-} from '../../data/locations';
+  makeButton, makeHeader, makeDivider, makeInventoryPanel, makeResultLine,
+  makeModal, makeTravelPanel,
+} from '../components';
+import { formatCash } from '../../util/format';
 import { getAvailableLoanAmounts, calculateInterestRate } from '../../systems/loan';
 import { bal } from '../../data/balance-types';
+import { getModal, openModal, closeModal } from '../modal';
 
 type Dispatch = (action: GameAction) => void;
 
+const SCREEN = 'dads_house';
 const dadBal = bal.dadsHouse;
 
 export function renderDadsHouse(state: GameState, container: HTMLElement, dispatch: Dispatch): void {
@@ -36,21 +28,46 @@ export function renderDadsHouse(state: GameState, container: HTMLElement, dispat
     renderDadGrave(state, screen, dispatch);
   }
 
-  // ── Inventory ──
+  // ── Section buttons ──
   screen.appendChild(makeDivider());
-  screen.appendChild(
-    makeInventoryPanel(
-      state.inventory,
-      (slotIndex) => dispatch({ type: 'CONSUME_SNACK', slotIndex }),
-      (slotIndex, godId) => dispatch({ type: 'USE_SCROLL', slotIndex, godId }),
-    ),
-  );
 
-  // ── Travel ──
-  renderTravelSection(state, screen, dispatch);
+  const invCount = state.inventory.filter(i => i !== null).length;
+  screen.appendChild(makeButton(
+    `INVENTORY (${invCount}/${state.inventory.length})`,
+    () => openModal(SCREEN, 'inventory', () => renderDadsHouse(state, container, dispatch)),
+    'section-btn',
+  ));
+
+  screen.appendChild(makeButton(
+    'TRAVEL',
+    () => openModal(SCREEN, 'travel', () => renderDadsHouse(state, container, dispatch)),
+    'section-btn',
+  ));
 
   container.replaceChildren();
   container.appendChild(screen);
+
+  // ── Active modal ──
+  const activeModal = getModal(SCREEN);
+  if (activeModal !== null) {
+    const onClose = () => closeModal(SCREEN, () => renderDadsHouse(state, container, dispatch));
+    let body: HTMLElement;
+    let title: string;
+
+    if (activeModal === 'inventory') {
+      title = 'INVENTORY';
+      body = makeInventoryPanel(
+        state.inventory,
+        (slotIndex) => dispatch({ type: 'CONSUME_SNACK', slotIndex }),
+        (slotIndex, godId) => dispatch({ type: 'USE_SCROLL', slotIndex, godId }),
+      );
+    } else {
+      title = 'TRAVEL';
+      body = makeTravelPanel(state, dispatch);
+    }
+
+    container.appendChild(makeModal(title, body, onClose));
+  }
 }
 
 function renderDadAlive(state: GameState, screen: HTMLElement, dispatch: Dispatch): void {
@@ -138,124 +155,4 @@ function renderDadGrave(_state: GameState, screen: HTMLElement, dispatch: Dispat
     'action-btn',
   ));
   screen.appendChild(makeResultLine(`(+${dadBal.graveManaRestore} mana, -${dadBal.graveChillLoss} chill)`));
-}
-
-function renderTravelSection(state: GameState, screen: HTMLElement, dispatch: Dispatch): void {
-  screen.appendChild(makeDivider());
-  screen.appendChild(makeHeader('TRAVEL'));
-
-  // Tower (home)
-  const towerCost = getTravelCostRaw(state.currentLocation, 'tower');
-  const towerClock = previewClock(state.clock, towerCost);
-  screen.appendChild(makeButton(
-    `TOWER (HOME)  \u2192  ${formatClock(towerClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: 'tower' }),
-    'nav-btn',
-  ));
-
-  for (const neighborhood of NEIGHBORHOODS) {
-    const nbLabel = document.createElement('p');
-    nbLabel.className = 'neighborhood-label';
-    nbLabel.textContent = neighborhood.name.toUpperCase();
-    screen.appendChild(nbLabel);
-
-    // Bodega
-    const bodegaId = getNeighborhoodBodega(neighborhood.id);
-    const bodegaData = getLocationData(bodegaId);
-    const bodegaCost = getTravelCostRaw(state.currentLocation, bodegaId);
-    const bodegaClock = previewClock(state.clock, bodegaCost);
-    screen.appendChild(makeButton(
-      `${bodegaData.displayName}  \u2192  ${formatClock(bodegaClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: bodegaId }),
-      'nav-btn',
-    ));
-
-    // Temples
-    const temples = getNeighborhoodTemples(neighborhood.id);
-    for (const temple of temples) {
-      if (temple.id === state.currentLocation) continue;
-      const tCost = getTravelCostRaw(state.currentLocation, temple.id);
-      const tClock = previewClock(state.clock, tCost);
-      screen.appendChild(makeButton(
-        `${temple.displayName}  \u2192  ${formatClock(tClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: temple.id }),
-        'nav-btn',
-      ));
-    }
-
-    // Furniture store
-    const fsId = getNeighborhoodFurnitureStore(neighborhood.id);
-    const fsData = getLocationData(fsId);
-    const fsCost = getTravelCostRaw(state.currentLocation, fsId);
-    const fsClock = previewClock(state.clock, fsCost);
-    screen.appendChild(makeButton(
-      `${fsData.displayName}  \u2192  ${formatClock(fsClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: fsId }),
-      'nav-btn',
-    ));
-
-    // University
-    const uniId = getNeighborhoodUniversity(neighborhood.id);
-    if (uniId) {
-      const uniData = getLocationData(uniId);
-      const uniCost = getTravelCostRaw(state.currentLocation, uniId);
-      const uniClock = previewClock(state.clock, uniCost);
-      screen.appendChild(makeButton(
-        `${uniData.displayName}  \u2192  ${formatClock(uniClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: uniId }),
-        'nav-btn',
-      ));
-    }
-
-    // Scroll store
-    const ssId = getNeighborhoodScrollStore(neighborhood.id);
-    const ssData = getLocationData(ssId);
-    const ssCost = getTravelCostRaw(state.currentLocation, ssId);
-    const ssClock = previewClock(state.clock, ssCost);
-    screen.appendChild(makeButton(
-      `${ssData.displayName}  \u2192  ${formatClock(ssClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: ssId }),
-      'nav-btn',
-    ));
-
-    // University bookstore
-    const bsId = getNeighborhoodBookstore(neighborhood.id);
-    if (bsId) {
-      const bsData = getLocationData(bsId);
-      const bsCost = getTravelCostRaw(state.currentLocation, bsId);
-      const bsClock = previewClock(state.clock, bsCost);
-      screen.appendChild(makeButton(
-        `${bsData.displayName}  \u2192  ${formatClock(bsClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: bsId }),
-        'nav-btn',
-      ));
-    }
-
-    // Dad's House (Richville only)
-    const dhId = getNeighborhoodDadsHouse(neighborhood.id);
-    if (dhId && dhId !== state.currentLocation) {
-      const dhData = getLocationData(dhId);
-      const dhCost = getTravelCostRaw(state.currentLocation, dhId);
-      const dhClock = previewClock(state.clock, dhCost);
-      const dhLabel = state.dadAlive ? dhData.displayName : "DAD'S GRAVE";
-      screen.appendChild(makeButton(
-        `${dhLabel}  \u2192  ${formatClock(dhClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: dhId }),
-        'nav-btn',
-      ));
-    }
-
-    // Sprint 25: University Bar (University Heights only)
-    const barId = getNeighborhoodBar(neighborhood.id);
-    if (barId) {
-      const barData = getLocationData(barId);
-      const barCost = getTravelCostRaw(state.currentLocation, barId);
-      const barClock = previewClock(state.clock, barCost);
-      screen.appendChild(makeButton(
-        `${barData.displayName}  \u2192  ${formatClock(barClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: barId }),
-        'nav-btn',
-      ));
-    }
-  }
 }

--- a/src/ui/screens/furniture-store.ts
+++ b/src/ui/screens/furniture-store.ts
@@ -1,30 +1,22 @@
 // Furniture Store screen: buy furniture for the wizard tower.
 // Sprint 13: Beds (swap upgrade), Lab Table, Bong.
+// Redesign: INVENTORY and TRAVEL moved to modal popups.
 
 import type { GameState } from '../../state/types';
 import type { GameAction } from '../../engine/actions';
 import { formatCash } from '../../util/format';
-import { makeButton, makeHeader, makeDivider, makeInventoryPanel } from '../components';
-import { formatClock, previewClock } from '../../engine/time';
-import { getTravelCostRaw } from '../../systems/travel';
 import {
-  getLocationData,
-  getLocationNeighborhood,
-  NEIGHBORHOODS,
-  getNeighborhoodBodega,
-  getNeighborhoodTemples,
-  getNeighborhoodFurnitureStore,
-  getNeighborhoodUniversity,
-  getNeighborhoodScrollStore,
-  getNeighborhoodBookstore,
-  getNeighborhoodDadsHouse,
-  getNeighborhoodBar,
-} from '../../data/locations';
+  makeButton, makeHeader, makeDivider, makeInventoryPanel, makeModal, makeTravelPanel,
+} from '../components';
+import { getLocationData } from '../../data/locations';
 import { FURNITURE_CATALOG } from '../../data/furniture';
 import { getBed, hasFurnitureSlot } from '../../systems/furniture';
 import { bal } from '../../data/balance-types';
+import { getModal, openModal, closeModal } from '../modal';
 
 type Dispatch = (action: GameAction) => void;
+
+const SCREEN = 'furniture_store';
 
 export function renderFurnitureStore(state: GameState, container: HTMLElement, dispatch: Dispatch): void {
   container.replaceChildren();
@@ -109,209 +101,43 @@ export function renderFurnitureStore(state: GameState, container: HTMLElement, d
     screen.appendChild(row);
   }
 
-  // ── Inventory panel ──
+  // ── Section buttons ──
   screen.appendChild(makeDivider());
-  screen.appendChild(
-    makeInventoryPanel(
-      state.inventory,
-      (slotIndex) => dispatch({ type: 'CONSUME_SNACK', slotIndex }),
-      (slotIndex, godId) => dispatch({ type: 'USE_SCROLL', slotIndex, godId }),
-    ),
-  );
 
-  // ── Travel section ──
-  screen.appendChild(makeDivider());
-  screen.appendChild(makeHeader('TRAVEL'));
-
-  // Tower (home) always first.
-  const towerCost = getTravelCostRaw(state.currentLocation, 'tower');
-  const towerClock = previewClock(state.clock, towerCost);
+  const invCount = state.inventory.filter(i => i !== null).length;
   screen.appendChild(makeButton(
-    `TOWER (HOME)  \u2192  ${formatClock(towerClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: 'tower' }),
-    'nav-btn',
+    `INVENTORY (${invCount}/${state.inventory.length})`,
+    () => openModal(SCREEN, 'inventory', () => renderFurnitureStore(state, container, dispatch)),
+    'section-btn',
   ));
 
-  // Other neighborhoods' locations.
-  const currentNeighborhood = getLocationNeighborhood(state.currentLocation);
-  for (const neighborhood of NEIGHBORHOODS) {
-    if (neighborhood.id === currentNeighborhood) continue;
-
-    const destId = getNeighborhoodBodega(neighborhood.id);
-    const destData = getLocationData(destId);
-    const cost = getTravelCostRaw(state.currentLocation, destId);
-    const arrival = previewClock(state.clock, cost);
-    screen.appendChild(makeButton(
-      `${neighborhood.name.toUpperCase()}: ${destData.displayName}  \u2192  ${formatClock(arrival)}`,
-      () => dispatch({ type: 'TRAVEL', destination: destId }),
-      'nav-btn',
-    ));
-
-    const temples = getNeighborhoodTemples(neighborhood.id);
-    for (const temple of temples) {
-      const tCost = getTravelCostRaw(state.currentLocation, temple.id);
-      const tClock = previewClock(state.clock, tCost);
-      screen.appendChild(makeButton(
-        `${temple.displayName}  \u2192  ${formatClock(tClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: temple.id }),
-        'nav-btn',
-      ));
-    }
-
-    const fsId = getNeighborhoodFurnitureStore(neighborhood.id);
-    const fsData = getLocationData(fsId);
-    const fsCost = getTravelCostRaw(state.currentLocation, fsId);
-    const fsClock = previewClock(state.clock, fsCost);
-    screen.appendChild(makeButton(
-      `${fsData.displayName}  \u2192  ${formatClock(fsClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: fsId }),
-      'nav-btn',
-    ));
-
-    const uniId = getNeighborhoodUniversity(neighborhood.id);
-    if (uniId) {
-      const uniData = getLocationData(uniId);
-      const uniCost = getTravelCostRaw(state.currentLocation, uniId);
-      const uniClock = previewClock(state.clock, uniCost);
-      screen.appendChild(makeButton(
-        `${uniData.displayName}  \u2192  ${formatClock(uniClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: uniId }),
-        'nav-btn',
-      ));
-    }
-
-    const ssId = getNeighborhoodScrollStore(neighborhood.id);
-    const ssData = getLocationData(ssId);
-    const ssCost = getTravelCostRaw(state.currentLocation, ssId);
-    const ssClock = previewClock(state.clock, ssCost);
-    screen.appendChild(makeButton(
-      `${ssData.displayName}  \u2192  ${formatClock(ssClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: ssId }),
-      'nav-btn',
-    ));
-
-    const bsId = getNeighborhoodBookstore(neighborhood.id);
-    if (bsId) {
-      const bsData = getLocationData(bsId);
-      const bsCost = getTravelCostRaw(state.currentLocation, bsId);
-      const bsClock = previewClock(state.clock, bsCost);
-      screen.appendChild(makeButton(
-        `${bsData.displayName}  \u2192  ${formatClock(bsClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: bsId }),
-        'nav-btn',
-      ));
-    }
-
-    // Dad's House (Richville only)
-    const dhId = getNeighborhoodDadsHouse(neighborhood.id);
-    if (dhId && dhId !== state.currentLocation) {
-      const dhData = getLocationData(dhId);
-      const dhCost = getTravelCostRaw(state.currentLocation, dhId);
-      const dhClock = previewClock(state.clock, dhCost);
-      const dhLabel = state.dadAlive ? dhData.displayName : "DAD'S GRAVE";
-      screen.appendChild(makeButton(
-        `${dhLabel}  \u2192  ${formatClock(dhClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: dhId }),
-        'nav-btn',
-      ));
-    }
-
-    // Sprint 25: University Bar (University Heights only)
-    const barId = getNeighborhoodBar(neighborhood.id);
-    if (barId) {
-      const barData = getLocationData(barId);
-      const barCost = getTravelCostRaw(state.currentLocation, barId);
-      const barClock = previewClock(state.clock, barCost);
-      screen.appendChild(makeButton(
-        `${barData.displayName}  \u2192  ${formatClock(barClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: barId }),
-        'nav-btn',
-      ));
-    }
-  }
-
-  // Local neighborhood locations (bodega, temples, university if any, scroll store, bookstore if any).
-  const localBodega = getNeighborhoodBodega(currentNeighborhood);
-  const localBodegaData = getLocationData(localBodega);
-  const lbCost = getTravelCostRaw(state.currentLocation, localBodega);
-  const lbClock = previewClock(state.clock, lbCost);
   screen.appendChild(makeButton(
-    `${localBodegaData.displayName}  \u2192  ${formatClock(lbClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: localBodega }),
-    'nav-btn',
+    'TRAVEL',
+    () => openModal(SCREEN, 'travel', () => renderFurnitureStore(state, container, dispatch)),
+    'section-btn',
   ));
-
-  const localTemples = getNeighborhoodTemples(currentNeighborhood);
-  for (const temple of localTemples) {
-    const tCost = getTravelCostRaw(state.currentLocation, temple.id);
-    const tClock = previewClock(state.clock, tCost);
-    screen.appendChild(makeButton(
-      `${temple.displayName}  \u2192  ${formatClock(tClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: temple.id }),
-      'nav-btn',
-    ));
-  }
-
-  const localUniId = getNeighborhoodUniversity(currentNeighborhood);
-  if (localUniId) {
-    const localUniData = getLocationData(localUniId);
-    const localUniCost = getTravelCostRaw(state.currentLocation, localUniId);
-    const localUniClock = previewClock(state.clock, localUniCost);
-    screen.appendChild(makeButton(
-      `${localUniData.displayName}  \u2192  ${formatClock(localUniClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: localUniId }),
-      'nav-btn',
-    ));
-  }
-
-  const localSsId = getNeighborhoodScrollStore(currentNeighborhood);
-  const localSsData = getLocationData(localSsId);
-  const localSsCost = getTravelCostRaw(state.currentLocation, localSsId);
-  const localSsClock = previewClock(state.clock, localSsCost);
-  screen.appendChild(makeButton(
-    `${localSsData.displayName}  \u2192  ${formatClock(localSsClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: localSsId }),
-    'nav-btn',
-  ));
-
-  const localBsId = getNeighborhoodBookstore(currentNeighborhood);
-  if (localBsId) {
-    const localBsData = getLocationData(localBsId);
-    const localBsCost = getTravelCostRaw(state.currentLocation, localBsId);
-    const localBsClock = previewClock(state.clock, localBsCost);
-    screen.appendChild(makeButton(
-      `${localBsData.displayName}  \u2192  ${formatClock(localBsClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: localBsId }),
-      'nav-btn',
-    ));
-  }
-
-  // Dad's House (Richville only)
-  const localDhId = getNeighborhoodDadsHouse(currentNeighborhood);
-  if (localDhId && localDhId !== state.currentLocation) {
-    const localDhData = getLocationData(localDhId);
-    const localDhCost = getTravelCostRaw(state.currentLocation, localDhId);
-    const localDhClock = previewClock(state.clock, localDhCost);
-    const localDhLabel = state.dadAlive ? localDhData.displayName : "DAD'S GRAVE";
-    screen.appendChild(makeButton(
-      `${localDhLabel}  \u2192  ${formatClock(localDhClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: localDhId }),
-      'nav-btn',
-    ));
-  }
-
-  // Sprint 25: University Bar (University Heights only)
-  const localBarId = getNeighborhoodBar(currentNeighborhood);
-  if (localBarId && localBarId !== state.currentLocation) {
-    const localBarData = getLocationData(localBarId);
-    const localBarCost = getTravelCostRaw(state.currentLocation, localBarId);
-    const localBarClock = previewClock(state.clock, localBarCost);
-    screen.appendChild(makeButton(
-      `${localBarData.displayName}  \u2192  ${formatClock(localBarClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: localBarId }),
-      'nav-btn',
-    ));
-  }
 
   container.appendChild(screen);
+
+  // ── Active modal ──
+  const activeModal = getModal(SCREEN);
+  if (activeModal !== null) {
+    const onClose = () => closeModal(SCREEN, () => renderFurnitureStore(state, container, dispatch));
+    let body: HTMLElement;
+    let title: string;
+
+    if (activeModal === 'inventory') {
+      title = 'INVENTORY';
+      body = makeInventoryPanel(
+        state.inventory,
+        (slotIndex) => dispatch({ type: 'CONSUME_SNACK', slotIndex }),
+        (slotIndex, godId) => dispatch({ type: 'USE_SCROLL', slotIndex, godId }),
+      );
+    } else {
+      title = 'TRAVEL';
+      body = makeTravelPanel(state, dispatch);
+    }
+
+    container.appendChild(makeModal(title, body, onClose));
+  }
 }

--- a/src/ui/screens/spell-scroll-store.ts
+++ b/src/ui/screens/spell-scroll-store.ts
@@ -1,32 +1,23 @@
 // Spell Scroll Store screen — buy one-use spell scrolls.
 // Sprint 16: one scroll store per neighborhood; standard pricing.
+// Redesign: INVENTORY and TRAVEL moved to modal popups.
 
 import type { GameState } from '../../state/types';
 import type { GameAction } from '../../engine/actions';
 import { formatCash } from '../../util/format';
-import { makeButton, makeHeader, makeDivider, makeInventoryPanel } from '../components';
-import { formatClock, previewClock } from '../../engine/time';
-import { getTravelCostRaw } from '../../systems/travel';
+import {
+  makeButton, makeHeader, makeDivider, makeInventoryPanel, makeModal, makeTravelPanel,
+} from '../components';
 import { canFitItems } from '../../systems/inventory';
 import { isSpellKnown } from '../../systems/spellbook';
 import { SPELL_CATALOG } from '../../data/spells';
-import {
-  getLocationData,
-  getLocationNeighborhood,
-  NEIGHBORHOODS,
-  getNeighborhoodBodega,
-  getNeighborhoodTemples,
-  getNeighborhoodFurnitureStore,
-  getNeighborhoodUniversity,
-  getNeighborhoodScrollStore,
-  getNeighborhoodBookstore,
-  getNeighborhoodDadsHouse,
-  getNeighborhoodBar,
-} from '../../data/locations';
+import { getLocationData } from '../../data/locations';
 import { bal } from '../../data/balance-types';
+import { getModal, openModal, closeModal } from '../modal';
 
 type Dispatch = (action: GameAction) => void;
 
+const SCREEN = 'spell_scroll_store';
 const scrollsBal = bal.scrolls;
 
 export function renderSpellScrollStore(state: GameState, container: HTMLElement, dispatch: Dispatch): void {
@@ -87,211 +78,43 @@ export function renderSpellScrollStore(state: GameState, container: HTMLElement,
     }
   }
 
-  // ── Inventory panel ──
+  // ── Section buttons ──
   screen.appendChild(makeDivider());
-  screen.appendChild(
-    makeInventoryPanel(
-      state.inventory,
-      (slotIndex) => dispatch({ type: 'CONSUME_SNACK', slotIndex }),
-      (slotIndex, godId) => dispatch({ type: 'USE_SCROLL', slotIndex, godId }),
-    ),
-  );
 
-  // ── Travel section ──
-  screen.appendChild(makeDivider());
-  screen.appendChild(makeHeader('TRAVEL'));
-
-  // Tower (home) always first.
-  const towerCost = getTravelCostRaw(state.currentLocation, 'tower');
-  const towerClock = previewClock(state.clock, towerCost);
+  const invCount = state.inventory.filter(i => i !== null).length;
   screen.appendChild(makeButton(
-    `TOWER (HOME)  \u2192  ${formatClock(towerClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: 'tower' }),
-    'nav-btn',
+    `INVENTORY (${invCount}/${state.inventory.length})`,
+    () => openModal(SCREEN, 'inventory', () => renderSpellScrollStore(state, container, dispatch)),
+    'section-btn',
   ));
 
-  const currentNeighborhood = getLocationNeighborhood(state.currentLocation);
-
-  // Other neighborhoods.
-  for (const neighborhood of NEIGHBORHOODS) {
-    if (neighborhood.id === currentNeighborhood) continue;
-
-    const destId = getNeighborhoodBodega(neighborhood.id);
-    const destData = getLocationData(destId);
-    const cost = getTravelCostRaw(state.currentLocation, destId);
-    const arrival = previewClock(state.clock, cost);
-    screen.appendChild(makeButton(
-      `${neighborhood.name.toUpperCase()}: ${destData.displayName}  \u2192  ${formatClock(arrival)}`,
-      () => dispatch({ type: 'TRAVEL', destination: destId }),
-      'nav-btn',
-    ));
-
-    const temples = getNeighborhoodTemples(neighborhood.id);
-    for (const temple of temples) {
-      const tCost = getTravelCostRaw(state.currentLocation, temple.id);
-      const tClock = previewClock(state.clock, tCost);
-      screen.appendChild(makeButton(
-        `${temple.displayName}  \u2192  ${formatClock(tClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: temple.id }),
-        'nav-btn',
-      ));
-    }
-
-    const fsId = getNeighborhoodFurnitureStore(neighborhood.id);
-    const fsData = getLocationData(fsId);
-    const fsCost = getTravelCostRaw(state.currentLocation, fsId);
-    const fsClock = previewClock(state.clock, fsCost);
-    screen.appendChild(makeButton(
-      `${fsData.displayName}  \u2192  ${formatClock(fsClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: fsId }),
-      'nav-btn',
-    ));
-
-    const uniId = getNeighborhoodUniversity(neighborhood.id);
-    if (uniId) {
-      const uniData = getLocationData(uniId);
-      const uniCost = getTravelCostRaw(state.currentLocation, uniId);
-      const uniClock = previewClock(state.clock, uniCost);
-      screen.appendChild(makeButton(
-        `${uniData.displayName}  \u2192  ${formatClock(uniClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: uniId }),
-        'nav-btn',
-      ));
-    }
-
-    const ssId = getNeighborhoodScrollStore(neighborhood.id);
-    const ssData = getLocationData(ssId);
-    const ssCost = getTravelCostRaw(state.currentLocation, ssId);
-    const ssClock = previewClock(state.clock, ssCost);
-    screen.appendChild(makeButton(
-      `${ssData.displayName}  \u2192  ${formatClock(ssClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: ssId }),
-      'nav-btn',
-    ));
-
-    const bsId = getNeighborhoodBookstore(neighborhood.id);
-    if (bsId) {
-      const bsData = getLocationData(bsId);
-      const bsCost = getTravelCostRaw(state.currentLocation, bsId);
-      const bsClock = previewClock(state.clock, bsCost);
-      screen.appendChild(makeButton(
-        `${bsData.displayName}  \u2192  ${formatClock(bsClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: bsId }),
-        'nav-btn',
-      ));
-    }
-
-    // Dad's House (Richville only)
-    const dhId = getNeighborhoodDadsHouse(neighborhood.id);
-    if (dhId && dhId !== state.currentLocation) {
-      const dhData = getLocationData(dhId);
-      const dhCost = getTravelCostRaw(state.currentLocation, dhId);
-      const dhClock = previewClock(state.clock, dhCost);
-      const dhLabel = state.dadAlive ? dhData.displayName : "DAD'S GRAVE";
-      screen.appendChild(makeButton(
-        `${dhLabel}  \u2192  ${formatClock(dhClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: dhId }),
-        'nav-btn',
-      ));
-    }
-
-    // Sprint 25: University Bar (University Heights only)
-    const barId = getNeighborhoodBar(neighborhood.id);
-    if (barId) {
-      const barData = getLocationData(barId);
-      const barCost = getTravelCostRaw(state.currentLocation, barId);
-      const barClock = previewClock(state.clock, barCost);
-      screen.appendChild(makeButton(
-        `${barData.displayName}  \u2192  ${formatClock(barClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: barId }),
-        'nav-btn',
-      ));
-    }
-  }
-
-  // Local neighborhood (same neighborhood — skip self, show everything else).
-  const localBodega = getNeighborhoodBodega(currentNeighborhood);
-  const localBodegaData = getLocationData(localBodega);
-  const lbCost = getTravelCostRaw(state.currentLocation, localBodega);
-  const lbClock = previewClock(state.clock, lbCost);
   screen.appendChild(makeButton(
-    `${localBodegaData.displayName}  \u2192  ${formatClock(lbClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: localBodega }),
-    'nav-btn',
+    'TRAVEL',
+    () => openModal(SCREEN, 'travel', () => renderSpellScrollStore(state, container, dispatch)),
+    'section-btn',
   ));
-
-  const localTemples = getNeighborhoodTemples(currentNeighborhood);
-  for (const temple of localTemples) {
-    const tCost = getTravelCostRaw(state.currentLocation, temple.id);
-    const tClock = previewClock(state.clock, tCost);
-    screen.appendChild(makeButton(
-      `${temple.displayName}  \u2192  ${formatClock(tClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: temple.id }),
-      'nav-btn',
-    ));
-  }
-
-  const localFsId = getNeighborhoodFurnitureStore(currentNeighborhood);
-  const localFsData = getLocationData(localFsId);
-  const localFsCost = getTravelCostRaw(state.currentLocation, localFsId);
-  const localFsClock = previewClock(state.clock, localFsCost);
-  screen.appendChild(makeButton(
-    `${localFsData.displayName}  \u2192  ${formatClock(localFsClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: localFsId }),
-    'nav-btn',
-  ));
-
-  const localUniId = getNeighborhoodUniversity(currentNeighborhood);
-  if (localUniId) {
-    const localUniData = getLocationData(localUniId);
-    const localUniCost = getTravelCostRaw(state.currentLocation, localUniId);
-    const localUniClock = previewClock(state.clock, localUniCost);
-    screen.appendChild(makeButton(
-      `${localUniData.displayName}  \u2192  ${formatClock(localUniClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: localUniId }),
-      'nav-btn',
-    ));
-  }
-
-  const localBsId = getNeighborhoodBookstore(currentNeighborhood);
-  if (localBsId) {
-    const localBsData = getLocationData(localBsId);
-    const localBsCost = getTravelCostRaw(state.currentLocation, localBsId);
-    const localBsClock = previewClock(state.clock, localBsCost);
-    screen.appendChild(makeButton(
-      `${localBsData.displayName}  \u2192  ${formatClock(localBsClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: localBsId }),
-      'nav-btn',
-    ));
-  }
-
-  // Dad's House (Richville only)
-  const localDhId = getNeighborhoodDadsHouse(currentNeighborhood);
-  if (localDhId && localDhId !== state.currentLocation) {
-    const localDhData = getLocationData(localDhId);
-    const localDhCost = getTravelCostRaw(state.currentLocation, localDhId);
-    const localDhClock = previewClock(state.clock, localDhCost);
-    const localDhLabel = state.dadAlive ? localDhData.displayName : "DAD'S GRAVE";
-    screen.appendChild(makeButton(
-      `${localDhLabel}  \u2192  ${formatClock(localDhClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: localDhId }),
-      'nav-btn',
-    ));
-  }
-
-  // Sprint 25: University Bar (University Heights only)
-  const localBarId = getNeighborhoodBar(currentNeighborhood);
-  if (localBarId && localBarId !== state.currentLocation) {
-    const localBarData = getLocationData(localBarId);
-    const localBarCost = getTravelCostRaw(state.currentLocation, localBarId);
-    const localBarClock = previewClock(state.clock, localBarCost);
-    screen.appendChild(makeButton(
-      `${localBarData.displayName}  \u2192  ${formatClock(localBarClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: localBarId }),
-      'nav-btn',
-    ));
-  }
-  // (Self — scroll store in current neighborhood — is omitted.)
 
   container.appendChild(screen);
+
+  // ── Active modal ──
+  const activeModal = getModal(SCREEN);
+  if (activeModal !== null) {
+    const onClose = () => closeModal(SCREEN, () => renderSpellScrollStore(state, container, dispatch));
+    let body: HTMLElement;
+    let title: string;
+
+    if (activeModal === 'inventory') {
+      title = 'INVENTORY';
+      body = makeInventoryPanel(
+        state.inventory,
+        (slotIndex) => dispatch({ type: 'CONSUME_SNACK', slotIndex }),
+        (slotIndex, godId) => dispatch({ type: 'USE_SCROLL', slotIndex, godId }),
+      );
+    } else {
+      title = 'TRAVEL';
+      body = makeTravelPanel(state, dispatch);
+    }
+
+    container.appendChild(makeModal(title, body, onClose));
+  }
 }

--- a/src/ui/screens/temple.ts
+++ b/src/ui/screens/temple.ts
@@ -1,29 +1,22 @@
 // Temple screen: donate to a god (private/public) and pray for timed buffs.
 // Sprint 9: each temple is dedicated to one god; actions infer god from location.
+// Redesign: INVENTORY and TRAVEL moved to modal popups.
 
 import type { GameState } from '../../state/types';
 import type { GameAction } from '../../engine/actions';
-import { makeButton, makeHeader, makeDivider, makeInventoryPanel } from '../components';
+import {
+  makeButton, makeHeader, makeDivider, makeInventoryPanel, makeModal, makeTravelPanel,
+} from '../components';
 import { formatCash } from '../../util/format';
 import { formatClock, previewClock } from '../../engine/time';
-import { getTravelCostRaw } from '../../systems/travel';
-import {
-  getLocationData,
-  getNeighborhoodTemples,
-  NEIGHBORHOODS,
-  getNeighborhoodBodega,
-  getNeighborhoodFurnitureStore,
-  getNeighborhoodUniversity,
-  getNeighborhoodScrollStore,
-  getNeighborhoodBookstore,
-  getNeighborhoodDadsHouse,
-  getNeighborhoodBar,
-} from '../../data/locations';
+import { getLocationData } from '../../data/locations';
 import { getGod } from '../../data/gods';
 import { bal } from '../../data/balance-types';
+import { getModal, openModal, closeModal } from '../modal';
 
 type Dispatch = (action: GameAction) => void;
 
+const SCREEN = 'temple';
 const prayerBal = bal.prayer;
 
 export function renderTemple(state: GameState, container: HTMLElement, dispatch: Dispatch): void {
@@ -150,135 +143,43 @@ export function renderTemple(state: GameState, container: HTMLElement, dispatch:
     screen.appendChild(btn);
   }
 
-  // ── Inventory ──
+  // ── Section buttons ──
   screen.appendChild(makeDivider());
-  screen.appendChild(
-    makeInventoryPanel(
-      state.inventory,
-      (slotIndex) => dispatch({ type: 'CONSUME_SNACK', slotIndex }),
-      (slotIndex, godId) => dispatch({ type: 'USE_SCROLL', slotIndex, godId }),
-    ),
-  );
 
-  // ── Travel ──
-  screen.appendChild(makeDivider());
-  screen.appendChild(makeHeader('TRAVEL'));
-
-  // Tower (home)
-  const towerCost = getTravelCostRaw(state.currentLocation, 'tower');
-  const towerClock = previewClock(state.clock, towerCost);
+  const invCount = state.inventory.filter(i => i !== null).length;
   screen.appendChild(makeButton(
-    `TOWER (HOME)  \u2192  ${formatClock(towerClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: 'tower' }),
-    'nav-btn',
+    `INVENTORY (${invCount}/${state.inventory.length})`,
+    () => openModal(SCREEN, 'inventory', () => renderTemple(state, container, dispatch)),
+    'section-btn',
   ));
 
-  // All neighborhoods: bodegas + temples + stores (skip current location)
-  for (const neighborhood of NEIGHBORHOODS) {
-    const nbLabel = document.createElement('p');
-    nbLabel.className = 'neighborhood-label';
-    nbLabel.textContent = neighborhood.name.toUpperCase();
-    screen.appendChild(nbLabel);
-
-    // Bodega
-    const bodegaId = getNeighborhoodBodega(neighborhood.id);
-    const bodegaData = getLocationData(bodegaId);
-    const bodegaCost = getTravelCostRaw(state.currentLocation, bodegaId);
-    const bodegaClock = previewClock(state.clock, bodegaCost);
-    screen.appendChild(makeButton(
-      `${bodegaData.displayName}  \u2192  ${formatClock(bodegaClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: bodegaId }),
-      'nav-btn',
-    ));
-
-    // Temples (skip self)
-    const temples = getNeighborhoodTemples(neighborhood.id);
-    for (const temple of temples) {
-      if (temple.id === state.currentLocation) continue;
-      const tCost = getTravelCostRaw(state.currentLocation, temple.id);
-      const tClock = previewClock(state.clock, tCost);
-      screen.appendChild(makeButton(
-        `${temple.displayName}  \u2192  ${formatClock(tClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: temple.id }),
-        'nav-btn',
-      ));
-    }
-
-    // Furniture store
-    const fsId = getNeighborhoodFurnitureStore(neighborhood.id);
-    const fsData = getLocationData(fsId);
-    const fsCost = getTravelCostRaw(state.currentLocation, fsId);
-    const fsClock = previewClock(state.clock, fsCost);
-    screen.appendChild(makeButton(
-      `${fsData.displayName}  \u2192  ${formatClock(fsClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: fsId }),
-      'nav-btn',
-    ));
-
-    // University (only university_heights has one)
-    const uniId = getNeighborhoodUniversity(neighborhood.id);
-    if (uniId) {
-      const uniData = getLocationData(uniId);
-      const uniCost = getTravelCostRaw(state.currentLocation, uniId);
-      const uniClock = previewClock(state.clock, uniCost);
-      screen.appendChild(makeButton(
-        `${uniData.displayName}  \u2192  ${formatClock(uniClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: uniId }),
-        'nav-btn',
-      ));
-    }
-
-    // Scroll store
-    const ssId = getNeighborhoodScrollStore(neighborhood.id);
-    const ssData = getLocationData(ssId);
-    const ssCost = getTravelCostRaw(state.currentLocation, ssId);
-    const ssClock = previewClock(state.clock, ssCost);
-    screen.appendChild(makeButton(
-      `${ssData.displayName}  \u2192  ${formatClock(ssClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: ssId }),
-      'nav-btn',
-    ));
-
-    // University bookstore (only university_heights has one)
-    const bsId = getNeighborhoodBookstore(neighborhood.id);
-    if (bsId) {
-      const bsData = getLocationData(bsId);
-      const bsCost = getTravelCostRaw(state.currentLocation, bsId);
-      const bsClock = previewClock(state.clock, bsCost);
-      screen.appendChild(makeButton(
-        `${bsData.displayName}  \u2192  ${formatClock(bsClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: bsId }),
-        'nav-btn',
-      ));
-    }
-
-    // Dad's House (Richville only)
-    const dhId = getNeighborhoodDadsHouse(neighborhood.id);
-    if (dhId && dhId !== state.currentLocation) {
-      const dhData = getLocationData(dhId);
-      const dhCost = getTravelCostRaw(state.currentLocation, dhId);
-      const dhClock = previewClock(state.clock, dhCost);
-      const dhLabel = state.dadAlive ? dhData.displayName : "DAD'S GRAVE";
-      screen.appendChild(makeButton(
-        `${dhLabel}  \u2192  ${formatClock(dhClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: dhId }),
-        'nav-btn',
-      ));
-    }
-
-    // Sprint 25: University Bar (University Heights only)
-    const barId = getNeighborhoodBar(neighborhood.id);
-    if (barId) {
-      const barData = getLocationData(barId);
-      const barCost = getTravelCostRaw(state.currentLocation, barId);
-      const barClock = previewClock(state.clock, barCost);
-      screen.appendChild(makeButton(
-        `${barData.displayName}  \u2192  ${formatClock(barClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: barId }),
-        'nav-btn',
-      ));
-    }
-  }
+  screen.appendChild(makeButton(
+    'TRAVEL',
+    () => openModal(SCREEN, 'travel', () => renderTemple(state, container, dispatch)),
+    'section-btn',
+  ));
 
   container.appendChild(screen);
+
+  // ── Active modal ──
+  const activeModal = getModal(SCREEN);
+  if (activeModal !== null) {
+    const onClose = () => closeModal(SCREEN, () => renderTemple(state, container, dispatch));
+    let body: HTMLElement;
+    let title: string;
+
+    if (activeModal === 'inventory') {
+      title = 'INVENTORY';
+      body = makeInventoryPanel(
+        state.inventory,
+        (slotIndex) => dispatch({ type: 'CONSUME_SNACK', slotIndex }),
+        (slotIndex, godId) => dispatch({ type: 'USE_SCROLL', slotIndex, godId }),
+      );
+    } else {
+      title = 'TRAVEL';
+      body = makeTravelPanel(state, dispatch);
+    }
+
+    container.appendChild(makeModal(title, body, onClose));
+  }
 }

--- a/src/ui/screens/tower.ts
+++ b/src/ui/screens/tower.ts
@@ -2,24 +2,15 @@
 // Actions: travel to any neighborhood's store, sleep (end the day).
 // Sprint 13: furniture panel with bong USE / recycle buttons.
 // Sprint 14: spellbook panel with CAST / ADD / REMOVE.
+// Redesign: INVENTORY / SPELLBOOK / FURNITURE / TRAVEL open DOS-style modals.
 
 import type { GameState } from '../../state/types';
 import type { GameAction } from '../../engine/actions';
-import { makeButton, makeHeader, makeDivider, makeInventoryPanel, makeStatsPanel } from '../components';
-import { formatClock, previewClock } from '../../engine/time';
-import { getTravelCostRaw } from '../../systems/travel';
 import {
-  NEIGHBORHOODS,
-  getNeighborhoodBodega,
-  getNeighborhoodTemples,
-  getNeighborhoodFurnitureStore,
-  getNeighborhoodUniversity,
-  getNeighborhoodScrollStore,
-  getNeighborhoodBookstore,
-  getNeighborhoodDadsHouse,
-  getNeighborhoodBar,
-  getLocationData,
-} from '../../data/locations';
+  makeButton, makeHeader, makeDivider, makeInventoryPanel, makeStatsPanel,
+  makeModal, makeTravelPanel,
+} from '../components';
+import { formatClock, previewClock } from '../../engine/time';
 import { getBed } from '../../systems/furniture';
 import { getSpellDef } from '../../data/spells';
 import { canAddToBook } from '../../systems/spellbook';
@@ -29,6 +20,7 @@ import { getProjectProgress, isProjectComplete } from '../../systems/projects';
 import { freeSlots } from '../../systems/inventory';
 import { progressBar } from '../../util/format';
 import { bal } from '../../data/balance-types';
+import { getModal, openModal, closeModal } from '../modal';
 
 // Sprint 15: reuse the same timestamp comparison for luck buff display.
 function isLuckBuffActiveNow(state: GameState): boolean {
@@ -41,6 +33,8 @@ function isLuckBuffActiveNow(state: GameState): boolean {
 }
 
 type Dispatch = (action: GameAction) => void;
+
+const SCREEN = 'tower';
 
 export function renderTower(state: GameState, container: HTMLElement, dispatch: Dispatch): void {
   container.replaceChildren();
@@ -58,137 +52,39 @@ export function renderTower(state: GameState, container: HTMLElement, dispatch: 
   flavor.textContent = 'Your dingy tower. Home sweet home.';
   screen.appendChild(flavor);
 
-  // ── Stats (Sprint 8) ──
+  // ── Stats (compact 2-row, no header) ──
   screen.appendChild(makeStatsPanel(state));
 
-  // ── Inventory (Sprint 7) ──
-  screen.appendChild(
-    makeInventoryPanel(
-      state.inventory,
-      (slotIndex) => dispatch({ type: 'CONSUME_SNACK', slotIndex }),
-      (slotIndex, godId) => dispatch({ type: 'USE_SCROLL', slotIndex, godId }),
-    ),
+  // ── Section buttons ──
+  const invCount = state.inventory.filter(i => i !== null).length;
+  const invBtn = makeButton(
+    `INVENTORY (${invCount}/${state.inventory.length})`,
+    () => openModal(SCREEN, 'inventory', () => renderTower(state, container, dispatch)),
+    'section-btn',
   );
+  screen.appendChild(invBtn);
 
-  // ── Spellbook (Sprint 14) ──
-  screen.appendChild(makeSpellbookPanel(state, dispatch));
+  const spellBtn = makeButton(
+    `SPELLBOOK (${state.equippedSpells.length}/${state.bookbinding})`,
+    () => openModal(SCREEN, 'spellbook', () => renderTower(state, container, dispatch)),
+    'section-btn',
+  );
+  screen.appendChild(spellBtn);
 
-  // ── Furniture (Sprint 13) ──
   const furnitureMax = bal.furniture.maxSlots;
-  screen.appendChild(makeFurniturePanel(state, furnitureMax, dispatch));
+  const furnitureBtn = makeButton(
+    `FURNITURE (${state.furniture.length}/${furnitureMax})`,
+    () => openModal(SCREEN, 'furniture', () => renderTower(state, container, dispatch)),
+    'section-btn',
+  );
+  screen.appendChild(furnitureBtn);
 
-  screen.appendChild(makeDivider());
-
-  // ── Travel destinations ──
-  // One section per neighborhood; each shows the neighborhood name and its bodega.
-  screen.appendChild(makeHeader('TRAVEL'));
-
-  for (const neighborhood of NEIGHBORHOODS) {
-    // Neighborhood label
-    const nbLabel = document.createElement('p');
-    nbLabel.className = 'neighborhood-label';
-    nbLabel.textContent = neighborhood.name.toUpperCase();
-    screen.appendChild(nbLabel);
-
-    const destId = getNeighborhoodBodega(neighborhood.id);
-    const destData = getLocationData(destId);
-    const travelCost = getTravelCostRaw('tower', destId);
-    const arrivalClock = previewClock(state.clock, travelCost);
-
-    const travelBtn = makeButton(
-      `${destData.displayName}  \u2192  ${formatClock(arrivalClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: destId }),
-      'nav-btn',
-    );
-    screen.appendChild(travelBtn);
-
-    // Sprint 9: temples in this neighborhood
-    const temples = getNeighborhoodTemples(neighborhood.id);
-    for (const temple of temples) {
-      const templeCost = getTravelCostRaw('tower', temple.id);
-      const templeClock = previewClock(state.clock, templeCost);
-      screen.appendChild(makeButton(
-        `${temple.displayName}  \u2192  ${formatClock(templeClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: temple.id }),
-        'nav-btn',
-      ));
-    }
-
-    // Sprint 13: furniture store in this neighborhood
-    const furnitureStoreId = getNeighborhoodFurnitureStore(neighborhood.id);
-    const furnitureStoreData = getLocationData(furnitureStoreId);
-    const fsCost = getTravelCostRaw('tower', furnitureStoreId);
-    const fsClock = previewClock(state.clock, fsCost);
-    screen.appendChild(makeButton(
-      `${furnitureStoreData.displayName}  \u2192  ${formatClock(fsClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: furnitureStoreId }),
-      'nav-btn',
-    ));
-
-    // Sprint 14: university in this neighborhood (only university_heights has one)
-    const uniId = getNeighborhoodUniversity(neighborhood.id);
-    if (uniId) {
-      const uniData = getLocationData(uniId);
-      const uniCost = getTravelCostRaw('tower', uniId);
-      const uniClock = previewClock(state.clock, uniCost);
-      screen.appendChild(makeButton(
-        `${uniData.displayName}  \u2192  ${formatClock(uniClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: uniId }),
-        'nav-btn',
-      ));
-    }
-
-    // Sprint 16: scroll store in this neighborhood
-    const ssId = getNeighborhoodScrollStore(neighborhood.id);
-    const ssData = getLocationData(ssId);
-    const ssCost = getTravelCostRaw('tower', ssId);
-    const ssClock = previewClock(state.clock, ssCost);
-    screen.appendChild(makeButton(
-      `${ssData.displayName}  \u2192  ${formatClock(ssClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: ssId }),
-      'nav-btn',
-    ));
-
-    // Sprint 16: university bookstore (only university_heights has one)
-    const bsId = getNeighborhoodBookstore(neighborhood.id);
-    if (bsId) {
-      const bsData = getLocationData(bsId);
-      const bsCost = getTravelCostRaw('tower', bsId);
-      const bsClock = previewClock(state.clock, bsCost);
-      screen.appendChild(makeButton(
-        `${bsData.displayName}  \u2192  ${formatClock(bsClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: bsId }),
-        'nav-btn',
-      ));
-    }
-
-    // Dad's House (Richville only)
-    const dhId = getNeighborhoodDadsHouse(neighborhood.id);
-    if (dhId && dhId !== state.currentLocation) {
-      const dhData = getLocationData(dhId);
-      const dhCost = getTravelCostRaw('tower', dhId);
-      const dhClock = previewClock(state.clock, dhCost);
-      const dhLabel = state.dadAlive ? dhData.displayName : "DAD'S GRAVE";
-      screen.appendChild(makeButton(
-        `${dhLabel}  \u2192  ${formatClock(dhClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: dhId }),
-        'nav-btn',
-      ));
-    }
-
-    // Sprint 25: University Bar (University Heights only)
-    const barId = getNeighborhoodBar(neighborhood.id);
-    if (barId) {
-      const barData = getLocationData(barId);
-      const barCost = getTravelCostRaw('tower', barId);
-      const barClock = previewClock(state.clock, barCost);
-      screen.appendChild(makeButton(
-        `${barData.displayName}  \u2192  ${formatClock(barClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: barId }),
-        'nav-btn',
-      ));
-    }
-  }
+  const travelBtn = makeButton(
+    'TRAVEL',
+    () => openModal(SCREEN, 'travel', () => renderTower(state, container, dispatch)),
+    'section-btn',
+  );
+  screen.appendChild(travelBtn);
 
   screen.appendChild(makeDivider());
 
@@ -208,23 +104,35 @@ export function renderTower(state: GameState, container: HTMLElement, dispatch: 
   if (!bed) sleepBtn.disabled = true;
   screen.appendChild(sleepBtn);
 
-  // ── Theme toggle ──
-  screen.appendChild(makeDivider());
-  const themeRow = document.createElement('div');
-  themeRow.className = 'theme-row';
-  const themes: Array<{ scheme: GameState['colorScheme']; label: string }> = [
-    { scheme: 'blue', label: 'BLU' },
-    { scheme: 'green', label: 'GRN' },
-    { scheme: 'orange', label: 'AMB' },
-  ];
-  for (const { scheme, label } of themes) {
-    const btn = makeButton(label, () => dispatch({ type: 'SET_THEME', scheme }), 'theme-btn');
-    if (state.colorScheme === scheme) btn.classList.add('active');
-    themeRow.appendChild(btn);
-  }
-  screen.appendChild(themeRow);
-
   container.appendChild(screen);
+
+  // ── Active modal ──
+  const activeModal = getModal(SCREEN);
+  if (activeModal !== null) {
+    const onClose = () => closeModal(SCREEN, () => renderTower(state, container, dispatch));
+    let body: HTMLElement;
+    let title: string;
+
+    if (activeModal === 'inventory') {
+      title = 'INVENTORY';
+      body = makeInventoryPanel(
+        state.inventory,
+        (slotIndex) => dispatch({ type: 'CONSUME_SNACK', slotIndex }),
+        (slotIndex, godId) => dispatch({ type: 'USE_SCROLL', slotIndex, godId }),
+      );
+    } else if (activeModal === 'spellbook') {
+      title = 'SPELLBOOK';
+      body = makeSpellbookPanel(state, dispatch);
+    } else if (activeModal === 'furniture') {
+      title = 'FURNITURE';
+      body = makeFurniturePanel(state, furnitureMax, dispatch);
+    } else {
+      title = 'TRAVEL';
+      body = makeTravelPanel(state, dispatch);
+    }
+
+    container.appendChild(makeModal(title, body, onClose));
+  }
 }
 
 // ── Spellbook Panel (Sprint 14) ──────────────────────────────────────────────
@@ -232,8 +140,6 @@ export function renderTower(state: GameState, container: HTMLElement, dispatch: 
 function makeSpellbookPanel(state: GameState, dispatch: Dispatch): HTMLElement {
   const panel = document.createElement('div');
   panel.className = 'spellbook-panel';
-
-  panel.appendChild(makeHeader(`SPELLBOOK (${state.equippedSpells.length}/${state.bookbinding})`));
 
   if (state.knownSpells.length === 0) {
     const empty = document.createElement('p');

--- a/src/ui/screens/university-bookstore.ts
+++ b/src/ui/screens/university-bookstore.ts
@@ -1,32 +1,23 @@
 // University Bookstore screen — buy spell scrolls at a premium.
 // Sprint 16: University Heights only; prices are 1.5× the standard scroll store.
+// Redesign: INVENTORY and TRAVEL moved to modal popups.
 
 import type { GameState } from '../../state/types';
 import type { GameAction } from '../../engine/actions';
 import { formatCash } from '../../util/format';
-import { makeButton, makeHeader, makeDivider, makeInventoryPanel } from '../components';
-import { formatClock, previewClock } from '../../engine/time';
-import { getTravelCostRaw } from '../../systems/travel';
+import {
+  makeButton, makeHeader, makeDivider, makeInventoryPanel, makeModal, makeTravelPanel,
+} from '../components';
 import { canFitItems } from '../../systems/inventory';
 import { isSpellKnown } from '../../systems/spellbook';
 import { SPELL_CATALOG } from '../../data/spells';
-import {
-  getLocationData,
-  getLocationNeighborhood,
-  NEIGHBORHOODS,
-  getNeighborhoodBodega,
-  getNeighborhoodTemples,
-  getNeighborhoodFurnitureStore,
-  getNeighborhoodUniversity,
-  getNeighborhoodScrollStore,
-  getNeighborhoodBookstore,
-  getNeighborhoodDadsHouse,
-  getNeighborhoodBar,
-} from '../../data/locations';
+import { getLocationData } from '../../data/locations';
 import { bal } from '../../data/balance-types';
+import { getModal, openModal, closeModal } from '../modal';
 
 type Dispatch = (action: GameAction) => void;
 
+const SCREEN = 'university_bookstore';
 const scrollsBal = bal.scrolls;
 
 export function renderUniversityBookstore(state: GameState, container: HTMLElement, dispatch: Dispatch): void {
@@ -94,208 +85,43 @@ export function renderUniversityBookstore(state: GameState, container: HTMLEleme
     }
   }
 
-  // ── Inventory panel ──
+  // ── Section buttons ──
   screen.appendChild(makeDivider());
-  screen.appendChild(
-    makeInventoryPanel(
-      state.inventory,
-      (slotIndex) => dispatch({ type: 'CONSUME_SNACK', slotIndex }),
-      (slotIndex, godId) => dispatch({ type: 'USE_SCROLL', slotIndex, godId }),
-    ),
-  );
 
-  // ── Travel section ──
-  screen.appendChild(makeDivider());
-  screen.appendChild(makeHeader('TRAVEL'));
-
-  // Tower (home) always first.
-  const towerCost = getTravelCostRaw(state.currentLocation, 'tower');
-  const towerClock = previewClock(state.clock, towerCost);
+  const invCount = state.inventory.filter(i => i !== null).length;
   screen.appendChild(makeButton(
-    `TOWER (HOME)  \u2192  ${formatClock(towerClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: 'tower' }),
-    'nav-btn',
+    `INVENTORY (${invCount}/${state.inventory.length})`,
+    () => openModal(SCREEN, 'inventory', () => renderUniversityBookstore(state, container, dispatch)),
+    'section-btn',
   ));
 
-  const currentNeighborhood = getLocationNeighborhood(state.currentLocation);
-
-  // Other neighborhoods.
-  for (const neighborhood of NEIGHBORHOODS) {
-    if (neighborhood.id === currentNeighborhood) continue;
-
-    const destId = getNeighborhoodBodega(neighborhood.id);
-    const destData = getLocationData(destId);
-    const cost = getTravelCostRaw(state.currentLocation, destId);
-    const arrival = previewClock(state.clock, cost);
-    screen.appendChild(makeButton(
-      `${neighborhood.name.toUpperCase()}: ${destData.displayName}  \u2192  ${formatClock(arrival)}`,
-      () => dispatch({ type: 'TRAVEL', destination: destId }),
-      'nav-btn',
-    ));
-
-    const temples = getNeighborhoodTemples(neighborhood.id);
-    for (const temple of temples) {
-      const tCost = getTravelCostRaw(state.currentLocation, temple.id);
-      const tClock = previewClock(state.clock, tCost);
-      screen.appendChild(makeButton(
-        `${temple.displayName}  \u2192  ${formatClock(tClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: temple.id }),
-        'nav-btn',
-      ));
-    }
-
-    const fsId = getNeighborhoodFurnitureStore(neighborhood.id);
-    const fsData = getLocationData(fsId);
-    const fsCost = getTravelCostRaw(state.currentLocation, fsId);
-    const fsClock = previewClock(state.clock, fsCost);
-    screen.appendChild(makeButton(
-      `${fsData.displayName}  \u2192  ${formatClock(fsClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: fsId }),
-      'nav-btn',
-    ));
-
-    const uniId = getNeighborhoodUniversity(neighborhood.id);
-    if (uniId) {
-      const uniData = getLocationData(uniId);
-      const uniCost = getTravelCostRaw(state.currentLocation, uniId);
-      const uniClock = previewClock(state.clock, uniCost);
-      screen.appendChild(makeButton(
-        `${uniData.displayName}  \u2192  ${formatClock(uniClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: uniId }),
-        'nav-btn',
-      ));
-    }
-
-    const ssId = getNeighborhoodScrollStore(neighborhood.id);
-    const ssData = getLocationData(ssId);
-    const ssCost = getTravelCostRaw(state.currentLocation, ssId);
-    const ssClock = previewClock(state.clock, ssCost);
-    screen.appendChild(makeButton(
-      `${ssData.displayName}  \u2192  ${formatClock(ssClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: ssId }),
-      'nav-btn',
-    ));
-
-    const bsId = getNeighborhoodBookstore(neighborhood.id);
-    if (bsId) {
-      const bsData = getLocationData(bsId);
-      const bsCost = getTravelCostRaw(state.currentLocation, bsId);
-      const bsClock = previewClock(state.clock, bsCost);
-      screen.appendChild(makeButton(
-        `${bsData.displayName}  \u2192  ${formatClock(bsClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: bsId }),
-        'nav-btn',
-      ));
-    }
-
-    // Dad's House (Richville only)
-    const dhId = getNeighborhoodDadsHouse(neighborhood.id);
-    if (dhId && dhId !== state.currentLocation) {
-      const dhData = getLocationData(dhId);
-      const dhCost = getTravelCostRaw(state.currentLocation, dhId);
-      const dhClock = previewClock(state.clock, dhCost);
-      const dhLabel = state.dadAlive ? dhData.displayName : "DAD'S GRAVE";
-      screen.appendChild(makeButton(
-        `${dhLabel}  \u2192  ${formatClock(dhClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: dhId }),
-        'nav-btn',
-      ));
-    }
-
-    // Sprint 25: University Bar (University Heights only)
-    const barId = getNeighborhoodBar(neighborhood.id);
-    if (barId) {
-      const barData = getLocationData(barId);
-      const barCost = getTravelCostRaw(state.currentLocation, barId);
-      const barClock = previewClock(state.clock, barCost);
-      screen.appendChild(makeButton(
-        `${barData.displayName}  \u2192  ${formatClock(barClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: barId }),
-        'nav-btn',
-      ));
-    }
-  }
-
-  // Local neighborhood (University Heights — show everything except self).
-  const localBodega = getNeighborhoodBodega(currentNeighborhood);
-  const localBodegaData = getLocationData(localBodega);
-  const lbCost = getTravelCostRaw(state.currentLocation, localBodega);
-  const lbClock = previewClock(state.clock, lbCost);
   screen.appendChild(makeButton(
-    `${localBodegaData.displayName}  \u2192  ${formatClock(lbClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: localBodega }),
-    'nav-btn',
+    'TRAVEL',
+    () => openModal(SCREEN, 'travel', () => renderUniversityBookstore(state, container, dispatch)),
+    'section-btn',
   ));
-
-  const localTemples = getNeighborhoodTemples(currentNeighborhood);
-  for (const temple of localTemples) {
-    const tCost = getTravelCostRaw(state.currentLocation, temple.id);
-    const tClock = previewClock(state.clock, tCost);
-    screen.appendChild(makeButton(
-      `${temple.displayName}  \u2192  ${formatClock(tClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: temple.id }),
-      'nav-btn',
-    ));
-  }
-
-  const localFsId = getNeighborhoodFurnitureStore(currentNeighborhood);
-  const localFsData = getLocationData(localFsId);
-  const localFsCost = getTravelCostRaw(state.currentLocation, localFsId);
-  const localFsClock = previewClock(state.clock, localFsCost);
-  screen.appendChild(makeButton(
-    `${localFsData.displayName}  \u2192  ${formatClock(localFsClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: localFsId }),
-    'nav-btn',
-  ));
-
-  const localUniId = getNeighborhoodUniversity(currentNeighborhood);
-  if (localUniId) {
-    const localUniData = getLocationData(localUniId);
-    const localUniCost = getTravelCostRaw(state.currentLocation, localUniId);
-    const localUniClock = previewClock(state.clock, localUniCost);
-    screen.appendChild(makeButton(
-      `${localUniData.displayName}  \u2192  ${formatClock(localUniClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: localUniId }),
-      'nav-btn',
-    ));
-  }
-
-  const localSsId = getNeighborhoodScrollStore(currentNeighborhood);
-  const localSsData = getLocationData(localSsId);
-  const localSsCost = getTravelCostRaw(state.currentLocation, localSsId);
-  const localSsClock = previewClock(state.clock, localSsCost);
-  screen.appendChild(makeButton(
-    `${localSsData.displayName}  \u2192  ${formatClock(localSsClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: localSsId }),
-    'nav-btn',
-  ));
-  // Dad's House (Richville only)
-  const localDhId = getNeighborhoodDadsHouse(currentNeighborhood);
-  if (localDhId && localDhId !== state.currentLocation) {
-    const localDhData = getLocationData(localDhId);
-    const localDhCost = getTravelCostRaw(state.currentLocation, localDhId);
-    const localDhClock = previewClock(state.clock, localDhCost);
-    const localDhLabel = state.dadAlive ? localDhData.displayName : "DAD'S GRAVE";
-    screen.appendChild(makeButton(
-      `${localDhLabel}  \u2192  ${formatClock(localDhClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: localDhId }),
-      'nav-btn',
-    ));
-  }
-
-  // Sprint 25: University Bar (University Heights only)
-  const localBarId = getNeighborhoodBar(currentNeighborhood);
-  if (localBarId && localBarId !== state.currentLocation) {
-    const localBarData = getLocationData(localBarId);
-    const localBarCost = getTravelCostRaw(state.currentLocation, localBarId);
-    const localBarClock = previewClock(state.clock, localBarCost);
-    screen.appendChild(makeButton(
-      `${localBarData.displayName}  \u2192  ${formatClock(localBarClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: localBarId }),
-      'nav-btn',
-    ));
-  }
-  // (Self — bookstore — is omitted.)
 
   container.appendChild(screen);
+
+  // ── Active modal ──
+  const activeModal = getModal(SCREEN);
+  if (activeModal !== null) {
+    const onClose = () => closeModal(SCREEN, () => renderUniversityBookstore(state, container, dispatch));
+    let body: HTMLElement;
+    let title: string;
+
+    if (activeModal === 'inventory') {
+      title = 'INVENTORY';
+      body = makeInventoryPanel(
+        state.inventory,
+        (slotIndex) => dispatch({ type: 'CONSUME_SNACK', slotIndex }),
+        (slotIndex, godId) => dispatch({ type: 'USE_SCROLL', slotIndex, godId }),
+      );
+    } else {
+      title = 'TRAVEL';
+      body = makeTravelPanel(state, dispatch);
+    }
+
+    container.appendChild(makeModal(title, body, onClose));
+  }
 }

--- a/src/ui/screens/university.ts
+++ b/src/ui/screens/university.ts
@@ -1,30 +1,22 @@
 // University screen — learn spells and bookbinding.
 // Sprint 14: classes available 10am–4pm, 3 random spells per day.
+// Redesign: INVENTORY and TRAVEL moved to modal popups.
 
 import type { GameState } from '../../state/types';
 import type { GameAction } from '../../engine/actions';
-import { makeButton, makeHeader, makeDivider, makeInventoryPanel } from '../components';
+import {
+  makeButton, makeHeader, makeDivider, makeInventoryPanel, makeModal, makeTravelPanel,
+} from '../components';
 import { formatCash } from '../../util/format';
-import { formatClock, previewClock } from '../../engine/time';
-import { getTravelCostRaw } from '../../systems/travel';
+import { formatClock } from '../../engine/time';
 import { getDailyClasses, calcLearningTime, isSpellKnown } from '../../systems/spellbook';
 import { BOOKBINDING_CLASS } from '../../data/spells';
-import {
-  NEIGHBORHOODS,
-  getNeighborhoodBodega,
-  getNeighborhoodTemples,
-  getNeighborhoodFurnitureStore,
-  getNeighborhoodScrollStore,
-  getNeighborhoodBookstore,
-  getNeighborhoodDadsHouse,
-  getNeighborhoodBar,
-  getLocationData,
-  getLocationNeighborhood,
-} from '../../data/locations';
 import { bal } from '../../data/balance-types';
+import { getModal, openModal, closeModal } from '../modal';
 
 type Dispatch = (action: GameAction) => void;
 
+const SCREEN = 'university';
 const uniBal = bal.university;
 
 export function renderUniversity(
@@ -124,183 +116,43 @@ export function renderUniversity(
   }
   screen.appendChild(bbBtn);
 
-  // ── Inventory panel ──
+  // ── Section buttons ──
   screen.appendChild(makeDivider());
-  screen.appendChild(
-    makeInventoryPanel(
-      state.inventory,
-      (slotIndex) => dispatch({ type: 'CONSUME_SNACK', slotIndex }),
-      (slotIndex, godId) => dispatch({ type: 'USE_SCROLL', slotIndex, godId }),
-    ),
-  );
 
-  // ── Travel section ──
-  screen.appendChild(makeDivider());
-  screen.appendChild(makeHeader('TRAVEL'));
-
-  // Tower (home) always first.
-  const towerCost = getTravelCostRaw(state.currentLocation, 'tower');
-  const towerClock = previewClock(state.clock, towerCost);
+  const invCount = state.inventory.filter(i => i !== null).length;
   screen.appendChild(makeButton(
-    `TOWER (HOME)  \u2192  ${formatClock(towerClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: 'tower' }),
-    'nav-btn',
+    `INVENTORY (${invCount}/${state.inventory.length})`,
+    () => openModal(SCREEN, 'inventory', () => renderUniversity(state, container, dispatch)),
+    'section-btn',
   ));
 
-  // Other neighborhoods' locations.
-  const currentNeighborhood = getLocationNeighborhood(state.currentLocation);
-  for (const neighborhood of NEIGHBORHOODS) {
-    if (neighborhood.id === currentNeighborhood) continue;
-    const destId = getNeighborhoodBodega(neighborhood.id);
-    const destData = getLocationData(destId);
-    const cost = getTravelCostRaw(state.currentLocation, destId);
-    const arrival = previewClock(state.clock, cost);
-    screen.appendChild(makeButton(
-      `${neighborhood.name.toUpperCase()}: ${destData.displayName}  \u2192  ${formatClock(arrival)}`,
-      () => dispatch({ type: 'TRAVEL', destination: destId }),
-      'nav-btn',
-    ));
-
-    const temples = getNeighborhoodTemples(neighborhood.id);
-    for (const temple of temples) {
-      const tCost = getTravelCostRaw(state.currentLocation, temple.id);
-      const tClock = previewClock(state.clock, tCost);
-      screen.appendChild(makeButton(
-        `${temple.displayName}  \u2192  ${formatClock(tClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: temple.id }),
-        'nav-btn',
-      ));
-    }
-
-    const fsId = getNeighborhoodFurnitureStore(neighborhood.id);
-    const fsData = getLocationData(fsId);
-    const fsCost = getTravelCostRaw(state.currentLocation, fsId);
-    const fsClock = previewClock(state.clock, fsCost);
-    screen.appendChild(makeButton(
-      `${fsData.displayName}  \u2192  ${formatClock(fsClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: fsId }),
-      'nav-btn',
-    ));
-
-    const ssId = getNeighborhoodScrollStore(neighborhood.id);
-    const ssData = getLocationData(ssId);
-    const ssCost = getTravelCostRaw(state.currentLocation, ssId);
-    const ssClock = previewClock(state.clock, ssCost);
-    screen.appendChild(makeButton(
-      `${ssData.displayName}  \u2192  ${formatClock(ssClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: ssId }),
-      'nav-btn',
-    ));
-
-    // Dad's House (Richville only)
-    const dhId = getNeighborhoodDadsHouse(neighborhood.id);
-    if (dhId && dhId !== state.currentLocation) {
-      const dhData = getLocationData(dhId);
-      const dhCost = getTravelCostRaw(state.currentLocation, dhId);
-      const dhClock = previewClock(state.clock, dhCost);
-      const dhLabel = state.dadAlive ? dhData.displayName : "DAD'S GRAVE";
-      screen.appendChild(makeButton(
-        `${dhLabel}  \u2192  ${formatClock(dhClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: dhId }),
-        'nav-btn',
-      ));
-    }
-
-    // Sprint 25: University Bar (University Heights only)
-    const barId = getNeighborhoodBar(neighborhood.id);
-    if (barId) {
-      const barData = getLocationData(barId);
-      const barCost = getTravelCostRaw(state.currentLocation, barId);
-      const barClock = previewClock(state.clock, barCost);
-      screen.appendChild(makeButton(
-        `${barData.displayName}  \u2192  ${formatClock(barClock)}`,
-        () => dispatch({ type: 'TRAVEL', destination: barId }),
-        'nav-btn',
-      ));
-    }
-  }
-
-  // Local neighborhood (University Heights — skip university itself, show everything else).
-  const localTemples = getNeighborhoodTemples(currentNeighborhood);
-  for (const temple of localTemples) {
-    const tCost = getTravelCostRaw(state.currentLocation, temple.id);
-    const tClock = previewClock(state.clock, tCost);
-    screen.appendChild(makeButton(
-      `${temple.displayName}  \u2192  ${formatClock(tClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: temple.id }),
-      'nav-btn',
-    ));
-  }
-
-  const localBodega = getNeighborhoodBodega(currentNeighborhood);
-  const localBodegaData = getLocationData(localBodega);
-  const lbCost = getTravelCostRaw(state.currentLocation, localBodega);
-  const lbClock = previewClock(state.clock, lbCost);
   screen.appendChild(makeButton(
-    `${localBodegaData.displayName}  \u2192  ${formatClock(lbClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: localBodega }),
-    'nav-btn',
+    'TRAVEL',
+    () => openModal(SCREEN, 'travel', () => renderUniversity(state, container, dispatch)),
+    'section-btn',
   ));
-
-  const localFsId = getNeighborhoodFurnitureStore(currentNeighborhood);
-  const localFsData = getLocationData(localFsId);
-  const localFsCost = getTravelCostRaw(state.currentLocation, localFsId);
-  const localFsClock = previewClock(state.clock, localFsCost);
-  screen.appendChild(makeButton(
-    `${localFsData.displayName}  \u2192  ${formatClock(localFsClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: localFsId }),
-    'nav-btn',
-  ));
-
-  const localSsId = getNeighborhoodScrollStore(currentNeighborhood);
-  const localSsData = getLocationData(localSsId);
-  const localSsCost = getTravelCostRaw(state.currentLocation, localSsId);
-  const localSsClock = previewClock(state.clock, localSsCost);
-  screen.appendChild(makeButton(
-    `${localSsData.displayName}  \u2192  ${formatClock(localSsClock)}`,
-    () => dispatch({ type: 'TRAVEL', destination: localSsId }),
-    'nav-btn',
-  ));
-
-  const localBsId = getNeighborhoodBookstore(currentNeighborhood);
-  if (localBsId) {
-    const localBsData = getLocationData(localBsId);
-    const localBsCost = getTravelCostRaw(state.currentLocation, localBsId);
-    const localBsClock = previewClock(state.clock, localBsCost);
-    screen.appendChild(makeButton(
-      `${localBsData.displayName}  \u2192  ${formatClock(localBsClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: localBsId }),
-      'nav-btn',
-    ));
-  }
-
-  // Dad's House (Richville only)
-  const localDhId = getNeighborhoodDadsHouse(currentNeighborhood);
-  if (localDhId && localDhId !== state.currentLocation) {
-    const localDhData = getLocationData(localDhId);
-    const localDhCost = getTravelCostRaw(state.currentLocation, localDhId);
-    const localDhClock = previewClock(state.clock, localDhCost);
-    const localDhLabel = state.dadAlive ? localDhData.displayName : "DAD'S GRAVE";
-    screen.appendChild(makeButton(
-      `${localDhLabel}  \u2192  ${formatClock(localDhClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: localDhId }),
-      'nav-btn',
-    ));
-  }
-
-  // Sprint 25: University Bar (University Heights only)
-  const localBarId = getNeighborhoodBar(currentNeighborhood);
-  if (localBarId && localBarId !== state.currentLocation) {
-    const localBarData = getLocationData(localBarId);
-    const localBarCost = getTravelCostRaw(state.currentLocation, localBarId);
-    const localBarClock = previewClock(state.clock, localBarCost);
-    screen.appendChild(makeButton(
-      `${localBarData.displayName}  \u2192  ${formatClock(localBarClock)}`,
-      () => dispatch({ type: 'TRAVEL', destination: localBarId }),
-      'nav-btn',
-    ));
-  }
-  // (Self — university — is omitted.)
 
   container.appendChild(screen);
+
+  // ── Active modal ──
+  const activeModal = getModal(SCREEN);
+  if (activeModal !== null) {
+    const onClose = () => closeModal(SCREEN, () => renderUniversity(state, container, dispatch));
+    let body: HTMLElement;
+    let title: string;
+
+    if (activeModal === 'inventory') {
+      title = 'INVENTORY';
+      body = makeInventoryPanel(
+        state.inventory,
+        (slotIndex) => dispatch({ type: 'CONSUME_SNACK', slotIndex }),
+        (slotIndex, godId) => dispatch({ type: 'USE_SCROLL', slotIndex, godId }),
+      );
+    } else {
+      title = 'TRAVEL';
+      body = makeTravelPanel(state, dispatch);
+    }
+
+    container.appendChild(makeModal(title, body, onClose));
+  }
 }


### PR DESCRIPTION
Refactor all 9 location screens to show only their primary actions
inline, moving INVENTORY, TRAVEL, SPELLBOOK, and FURNITURE into
reusable DOS-style modal overlays. Introduces modal.ts state manager,
makeTravelPanel() and makeModal() shared components, compact 2-row
stats panel, and HUD-level theme toggle buttons (BLU/GRN/AMB).

https://claude.ai/code/session_012KkPzNu4ftFKNkhNmpEXr5