### PR TITLE
Scratch ticket UI: borderless cells, 3-tap reveal, RST button

### DIFF
--- a/src/engine/actions.ts
+++ b/src/engine/actions.ts
@@ -7,7 +7,7 @@ export type GameAction =
   // Buy tickets and/or snacks at a bodega.  Snacks are added to inventory;
   // if tickets > 0, a scratch session begins.
   | { type: 'BUY_TICKETS'; quantities: Record<string, number>; snacks?: string[] }
-  // Tap a scratch cell to advance its reveal state (0→1→2→3→4).
+  // Tap a scratch cell to advance its reveal state (0→1→2→3=revealed).
   | { type: 'SCRATCH_CELL'; cellIndex: number }
   // Move to the next ticket after the current one is fully revealed.
   | { type: 'ADVANCE_TICKET' }

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -128,8 +128,8 @@ export interface LuckBuff {
 
 // ─── Scratch Session ──────────────────────────────────────────────────────────
 
-// 0 = █ covered, 1 = ▓, 2 = ▒, 3 = ░, 4 = glyph revealed
-export type CellState = 0 | 1 | 2 | 3 | 4;
+// 0 = █ covered, 1 = ▓, 2 = ░, 3 = glyph revealed (3 taps to reveal)
+export type CellState = 0 | 1 | 2 | 3;
 
 export interface TicketCell {
   symbolId: number;  // 1–30

--- a/src/style.css
+++ b/src/style.css
@@ -333,26 +333,25 @@ html, body {
 }
 
 .scratch-cell {
-  background: var(--btn-bg);
+  background: transparent;
   color: var(--fg);
-  border: 1px solid var(--border);
+  border: none;
   cursor: pointer;
   font-family: inherit;
   font-size: 1.4em;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 56px;
-  height: 56px;
-  min-width: 44px;
+  flex: 1;
+  height: 52px;
   min-height: 44px;
-  transition: background 0.08s;
+  transition: opacity 0.08s;
   -webkit-tap-highlight-color: transparent;
   user-select: none;
 }
 
 .scratch-cell:hover {
-  background: var(--btn-hover);
+  opacity: 0.75;
 }
 
 .scratch-cell.scratching {
@@ -361,7 +360,7 @@ html, body {
 
 .scratch-cell.revealed {
   background: transparent;
-  border-color: transparent;
+  border: none;
   cursor: default;
   font-size: 1.6em;
 }
@@ -492,7 +491,7 @@ html, body {
 
 .scratch-cells {
   display: flex;
-  gap: 6px;
+  gap: 0;
   flex: 1;
 }
 
@@ -649,12 +648,17 @@ html, body {
   flex-shrink: 0;
 }
 
+.hud-reset-btn {
+  color: var(--muted);
+  border-color: var(--muted);
+  margin-left: 4px;
+}
+
 /* ─── Responsive ─────────────────────────────────────────────────────────────── */
 
 @media (max-width: 360px) {
   .scratch-cell {
-    width: 48px;
-    height: 48px;
+    height: 44px;
     font-size: 1.2em;
   }
 

--- a/src/systems/scratch.ts
+++ b/src/systems/scratch.ts
@@ -256,14 +256,14 @@ export function scratchCell(
   if (ticket.revealed) return state;
 
   const cell = ticket.cells[cellIndex];
-  if (!cell || cell.state >= 4) return state;
+  if (!cell || cell.state >= 3) return state;
 
   // Clone tickets array and the specific ticket.
   const newTickets = [...session.tickets];
   const newCells = [...ticket.cells];
   newCells[cellIndex] = { ...cell, state: (cell.state + 1) as CellState };
 
-  const allRevealed = newCells.every(c => c.state >= 4);
+  const allRevealed = newCells.every(c => c.state >= 3);
 
   const newTicket: GeneratedTicket = {
     ...ticket,

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -43,6 +43,17 @@ export function renderHUD(state: GameState, el: HTMLElement, dispatch: Dispatch)
     themeGroup.appendChild(btn);
   }
 
+  const rstBtn = document.createElement('button');
+  rstBtn.className = 'hud-theme-btn hud-reset-btn';
+  rstBtn.textContent = 'RST';
+  rstBtn.title = 'Reset game (debug)';
+  rstBtn.addEventListener('click', () => {
+    if (window.confirm('Reset all progress and start a new game?')) {
+      dispatch({ type: 'NEW_GAME' });
+    }
+  });
+  themeGroup.appendChild(rstBtn);
+
   row1.appendChild(cashEl);
   row1.appendChild(clockEl);
   row1.appendChild(themeGroup);

--- a/src/ui/screens/scratch.ts
+++ b/src/ui/screens/scratch.ts
@@ -10,8 +10,8 @@ import { makeButton, makeHeader, makePanel, makeDivider, makeResultLine } from '
 
 type Dispatch = (action: GameAction) => void;
 
-// Degradation sequence: covered → revealed.
-const CELL_CHARS = ['█', '▓', '▒', '░'];
+// Degradation sequence: covered → revealed (3 taps).
+const CELL_CHARS = ['█', '▓', '░'];
 
 // ─── Full Render ──────────────────────────────────────────────────────────────
 
@@ -110,7 +110,7 @@ export function renderScratch(
     const t = state.scratchSession.tickets[state.scratchSession.currentTicketIndex];
     if (!t || t.revealed) return;
     t.cells.forEach((cell, idx) => {
-      const steps = 4 - cell.state;
+      const steps = 3 - cell.state;
       for (let i = 0; i < steps; i++) {
         dispatch({ type: 'SCRATCH_CELL', cellIndex: idx });
       }
@@ -159,8 +159,8 @@ export function updateScratchCell(
   );
   if (!cellEl) return;
 
-  if (cell.state < 4) {
-    // Show the degradation char for the current state (0=█ 1=▓ 2=▒ 3=░).
+  if (cell.state < 3) {
+    // Show the degradation char for the current state (0=█ 1=▓ 2=░).
     cellEl.textContent = CELL_CHARS[cell.state] ?? CELL_CHARS[0];
     cellEl.className = cell.state > 0 ? 'scratch-cell scratching' : 'scratch-cell';
   } else {
@@ -211,7 +211,7 @@ function buildGrid(ticket: GeneratedTicket, dispatch: Dispatch): HTMLElement {
       btn.className = 'scratch-cell';
       btn.dataset.cellIndex = String(idx);
 
-      if (cell.state < 4) {
+      if (cell.state < 3) {
         btn.textContent = CELL_CHARS[cell.state];
         if (cell.state > 0) btn.classList.add('scratching');
       } else {
@@ -222,7 +222,7 @@ function buildGrid(ticket: GeneratedTicket, dispatch: Dispatch): HTMLElement {
         btn.setAttribute('aria-label', sym.name);
       }
 
-      if (cell.state < 4) {
+      if (cell.state < 3) {
         btn.addEventListener('click', () =>
           dispatch({ type: 'SCRATCH_CELL', cellIndex: idx }),
         );


### PR DESCRIPTION
- Remove borders and box backgrounds from unscratched scratch cells;
  cells now sit flush against each other (gap: 0) so each row reads
  as one continuous strip, matching the look of a real scratch-off ticket
- Reduce reveal steps from 4 to 3 taps (█ → ▓ → ░ → revealed);
  CellState narrowed to 0|1|2|3, reveal threshold updated in both the
  system and UI layers
- Add RST debug button to HUD (next to theme toggles) that fires
  NEW_GAME after a confirm() prompt

https://claude.ai/code/session_01MKhxo3msETdANijDyyb3mg