### PR TITLE
Fix lotto cell spacing: use fixed width instead of flex:1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,7 @@ Always read `scope.md` before implementing any mechanic. If something isn't in s
 - **Use `bal` from `balance-types.ts`** for all balance data access. Never import `balance.json` directly.
 - **Use `toTotalMinutes()` from `time.ts`** for timestamp comparisons. Never reimplement locally.
 - **Use `container.replaceChildren()`** to clear DOM elements. Never use `innerHTML = ''`.
+- **Independently diagnose bugs before fixing.** When a user reports a visual or behavioral bug, read the relevant code first and derive your own root cause. Do not treat the user's description as a technical diagnosis — they describe symptoms, not causes.
 
 ## Style
 

--- a/src/style.css
+++ b/src/style.css
@@ -342,7 +342,7 @@ html, body {
   display: flex;
   align-items: center;
   justify-content: center;
-  flex: 1;
+  width: 44px;
   height: 52px;
   min-height: 44px;
   transition: opacity 0.08s;
@@ -493,6 +493,7 @@ html, body {
   display: flex;
   gap: 0;
   flex: 1;
+  justify-content: center;
 }
 
 .row-prize {


### PR DESCRIPTION
Cells had flex:1 so each grew to fill 1/N of the row width, making
characters look spread apart even with gap:0. Replace with width:44px
so cells are compact, and center the group with justify-content:center.

Also adds a CLAUDE.md rule to always independently diagnose bugs from
code rather than relying on user symptom descriptions.

https://claude.ai/code/session_019t8wSrAsCZvi9BeddzBqA7